### PR TITLE
fix ccordinate type recognition

### DIFF
--- a/pubchempy.py
+++ b/pubchempy.py
@@ -247,9 +247,9 @@ class Compound(object):
 
     @property
     def coordinate_type(self):
-        if 'twod' in self.record['coords']['type']:
+        if 'twod' in self.record['coords'][0]['type']:
             return '2d'
-        elif 'threed' in self.record['coords']['type']:
+        elif 'threed' in self.record['coords'][0]['type']:
             return '3d'
 
     @property

--- a/pubchempy_test.py
+++ b/pubchempy_test.py
@@ -70,6 +70,7 @@ class TestPubChemPy(unittest.TestCase):
         print c.defined_bond_stereo_count
         print c.undefined_bond_stereo_count
         print c.covalent_unit_count
+        print c.coordinate_type
 
         c = Compound.from_cid(1, record_type='3d')
         print c.volume_3d
@@ -83,6 +84,7 @@ class TestPubChemPy(unittest.TestCase):
         print c.shape_selfoverlap_3d
         print c.feature_selfoverlap_3d
         print c.shape_fingerprint_3d
+        print c.coordinate_type
 
     def test_csaids(self):
         print get_cids('Aspirin', 'name', 'substance')


### PR DESCRIPTION
`self.record['coords']` is a list. By getting the first member, the `['type']` call works correctly
