### PR TITLE
Decode fingerprint

### DIFF
--- a/pubchempy.py
+++ b/pubchempy.py
@@ -17,6 +17,7 @@ import os
 import sys
 import time
 import warnings
+import binascii
 
 try:
     from urllib.error import HTTPError
@@ -900,7 +901,15 @@ class Compound(object):
 
         More information at ftp://ftp.ncbi.nlm.nih.gov/pubchem/specifications/pubchem_fingerprints.txt
         """
-        return _parse_prop({'implementation': 'E_SCREEN'}, self.record['props'])
+        hex_fingerprint = _parse_prop({'implementation': 'E_SCREEN'},
+                                      self.record['props'])
+        hex_bytes = binascii.unhexlify(hex_fingerprint)
+
+        # Skip first 4 bytes that contain length of fingerprint.
+        binary = ''.join(format(hex_byte, '08b') for hex_byte in hex_bytes[4:])
+
+        # Last 7 bits are padding.
+        return binary[:-7]
 
     @property
     def heavy_atom_count(self):

--- a/pubchempy.py
+++ b/pubchempy.py
@@ -253,7 +253,9 @@ def request(identifier, namespace='cid', domain='compound', operation=None, outp
     urlid, postdata = None, None
     if namespace == 'sourceid':
         identifier = identifier.replace('/', '.')
-    if namespace in ['listkey', 'formula', 'sourceid'] or (searchtype and namespace == 'cid') or domain == 'sources':
+    if namespace in ['listkey', 'formula', 'sourceid'] \
+            or searchtype == 'xref' \
+            or (searchtype and namespace == 'cid') or domain == 'sources':
         urlid = quote(identifier.encode('utf8'))
     else:
         postdata = urlencode([(namespace, identifier)]).encode('utf8')
@@ -273,7 +275,7 @@ def request(identifier, namespace='cid', domain='compound', operation=None, outp
 
 def get(identifier, namespace='cid', domain='compound', operation=None, output='JSON', searchtype=None, **kwargs):
     """Request wrapper that automatically handles async requests."""
-    if searchtype or namespace in ['formula']:
+    if (searchtype and searchtype != 'xref') or namespace in ['formula']:
         response = request(identifier, namespace, domain, None, 'JSON', searchtype, **kwargs).read()
         status = json.loads(response.decode())
         if 'Waiting' in status and 'ListKey' in status['Waiting']:

--- a/pubchempy_test.py
+++ b/pubchempy_test.py
@@ -314,10 +314,10 @@ class TestSubstance(unittest.TestCase):
 
     def test_substance_equality(self):
         self.assertEqual(Substance.from_sid(24864499), Substance.from_sid(24864499))
-        self.assertEqual(get_substances('Coumarin 343', 'name')[0], get_substances(24864499)[0])
+        self.assertEqual(get_substances('Coumarin 343, Dye Content 97 %', 'name')[0], get_substances(24864499)[0])
 
     def test_synonyms(self):
-        self.assertGreater(len(self.s1.synonyms), 1)
+        self.assertEqual(len(self.s1.synonyms), 1)
 
     def test_source(self):
         self.assertEqual(self.s1.source_name, 'Sigma-Aldrich')

--- a/pubchempy_test.py
+++ b/pubchempy_test.py
@@ -49,6 +49,19 @@ class TestRequest(unittest.TestCase):
         r2 = get_json('C10H21N', 'formula', listkey_count=3)
         self.assertTrue('PC_Compounds' in r2 and len(r2['PC_Compounds']) == 3)
 
+    def test_xref_request(self):
+        response = request('US6187568B1', 'PatentID', 'substance',
+                            operation='sids', searchtype='xref')
+        self.assertEqual(response.code, 200)
+        response2 = get_json('US6187568B1', 'PatentID', 'substance',
+                            operation='sids', searchtype='xref')
+        self.assertTrue('IdentifierList' in response2)
+        self.assertTrue('SID' in response2['IdentifierList'])
+
+        sids = get_sids('US6187568B1', 'PatentID', 'substance',
+                        searchtype='xref')
+        self.assertTrue(all(isinstance(sid, int) for sid in sids))
+
 
 class TestProperties(unittest.TestCase):
 

--- a/pubchempy_test.py
+++ b/pubchempy_test.py
@@ -248,6 +248,11 @@ class TestCompound(unittest.TestCase):
             self.assertEqual(w[0].category, PubChemPyDeprecationWarning)
             self.assertEqual(str(w[0].message), 'Dictionary style access to Atom attributes is deprecated')
 
+    def test_fingerprint(self):
+        for compound in (self.c1, self.c2):
+            self.assertEqual(len(compound.fingerprint), 881)
+            self.assertTrue(all(c in '01' for c in compound.fingerprint))
+
 
 class TestCompound3d(unittest.TestCase):
 


### PR DESCRIPTION
The fingerprint provided was the raw hex-string obtained through the REST API. I added decoding of the hex string according to the documentation at ftp://ftp.ncbi.nlm.nih.gov/pubchem/specifications/pubchem_fingerprints.txt 

Now `Compound.fingerprint` returns the 881 bit fingerprint which can be used directly for similarity comparisons.