### PR TITLE
Decode CACTVS fingerprint to binary string

### DIFF
--- a/pubchempy.py
+++ b/pubchempy.py
@@ -893,15 +893,18 @@ class Compound(object):
 
     @property
     def fingerprint(self):
+        """Raw padded and hex-encoded fingerprint, as returned by the PUG REST API."""
+        return _parse_prop({'implementation': 'E_SCREEN'}, self.record['props'])
+
+    @property
+    def cactvs_fingerprint(self):
         """PubChem CACTVS fingerprint.
 
         Each bit in the fingerprint represents the presence or absence of one of 881 chemical substructures.
 
         More information at ftp://ftp.ncbi.nlm.nih.gov/pubchem/specifications/pubchem_fingerprints.txt
         """
-        hex_fingerprint = _parse_prop({'implementation': 'E_SCREEN'},
-                                      self.record['props'])
-        hex_bytes = binascii.unhexlify(hex_fingerprint)
+        hex_bytes = binascii.unhexlify(self.fingerprint)
 
         # Skip first 4 bytes that contain length of fingerprint.
         binary = ''.join(format(hex_byte, '08b') for hex_byte in hex_bytes[4:])

--- a/pubchempy.py
+++ b/pubchempy.py
@@ -17,6 +17,7 @@ import os
 import sys
 import time
 import warnings
+import binascii
 
 try:
     from urllib.error import HTTPError
@@ -898,7 +899,15 @@ class Compound(object):
 
         More information at ftp://ftp.ncbi.nlm.nih.gov/pubchem/specifications/pubchem_fingerprints.txt
         """
-        return _parse_prop({'implementation': 'E_SCREEN'}, self.record['props'])
+        hex_fingerprint = _parse_prop({'implementation': 'E_SCREEN'},
+                                      self.record['props'])
+        hex_bytes = binascii.unhexlify(hex_fingerprint)
+
+        # Skip first 4 bytes that contain length of fingerprint.
+        binary = ''.join(format(hex_byte, '08b') for hex_byte in hex_bytes[4:])
+
+        # Last 7 bits are padding.
+        return binary[:-7]
 
     @property
     def heavy_atom_count(self):

--- a/pubchempy_test.py
+++ b/pubchempy_test.py
@@ -235,6 +235,12 @@ class TestCompound(unittest.TestCase):
             self.assertEqual(w[0].category, PubChemPyDeprecationWarning)
             self.assertEqual(str(w[0].message), 'Dictionary style access to Atom attributes is deprecated')
 
+    def test_fingerprint(self):
+        # CACTVS fingerprint is 881 bits
+        self.assertEqual(len(self.c1.cactvs_fingerprint), 881)
+        # Raw fingerprint has 4 byte prefix, 7 bit suffix, and is hex encoded (/4) = 230
+        self.assertEqual(len(self.c1.fingerprint), (881 + (4 * 8) + 7) / 4)
+
 
 class TestCompound3d(unittest.TestCase):
 


### PR DESCRIPTION
Decode fingerprint using method by @RickardSjogren in #21 but put in a separate `cactvs_fingerprint` method to maintain backwards compatibility with the `fingerprint` method.

Replaces #21
Fixes #15