### PR TITLE
Added `find_compounds()` functionality

### DIFF
--- a/examples/2-getting-started.ipynb
+++ b/examples/2-getting-started.ipynb
@@ -22,10 +22,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pubchempy as pcp"
@@ -40,10 +38,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -51,7 +47,7 @@
        "Compound(5090)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -70,10 +66,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -89,16 +83,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "314.35566\n"
+      "314.355\n"
      ]
     }
    ],
@@ -108,10 +100,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -127,10 +117,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -146,10 +134,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -165,16 +151,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[u'rofecoxib', u'Vioxx', u'Ceoxx', u'162011-90-7', u'MK 966', u'MK-966', u'4-[4-(methylsulfonyl)phenyl]-3-phenylfuran-2(5H)-one', u'MK-0966', u'Vioxx (trademark)', u'MK 0966', u'CCRIS 8967', u'CHEBI:8887', u'Vioxx (TN)', u'HSDB 7262', u'Spectrum_000119', u'SpecPlus_000669', u'Spectrum2_000446', u'Spectrum3_001153', u'Spectrum4_000631', u'Spectrum5_001598', u'UNII-0QTW8Z7MCR', u'MK 996', u'MK0966', u'CHEMBL122', u'AC1L1JL6', u'KS-1107', u'3-(4-methylsulfonylphenyl)-4-phenyl-2H-furan-5-one', u'4-(4-methylsulfonylphenyl)-3-phenyl-5H-furan-2-one', u'NCGC00095118-01', u'BSPBio_002705', u'KBioGR_001242', u'KBioGR_002345', u'KBioSS_000559', u'KBioSS_002348', u'Rofecoxib (JAN/USAN/INN)', u'BIDD:GT0399', u'Bio-0094', u'DivK1c_006765', u'4-[4-(methylsulfonyl)phenyl]-3-phenyl-2(5H)-furanone', u'SPBio_000492', u'SPECTRUM1504235', u'MLS000759440', u'MLS001165770', u'MLS001195623', u'MLS001424113', u'Jsp003237', u'C17H14O4S', u'KBio1_001709', u'KBio2_000559', u'KBio2_002345', u'KBio2_003127', u'KBio2_004913', u'KBio2_005695', u'KBio2_007481', u'KBio3_002205', u'KBio3_002825', u'cMAP_000024', u'MolPort-000-883-878', u'MolPort-006-817-786', u'HMS1922H11', u'HMS2051G16', u'HMS2089H20', u'HMS2093E04', u'NSC720256', u'STK635144', u'ZINC00007455', u'AKOS000280931', u'4-(4-(Methylsulfonyl)phenyl)-3-phenyl-2(5H)-furanone', u'4-(p-(Methylsulfonyl)phenyl)-3-phenyl-2(5H)-furanone', u'DB00533', u'MK 0996', u'2(5H)-Furanone, 4-(4-(methylsulfonyl)phenyl)-3-phenyl-', u'3-Phenyl-4-(4-(methylsulfonyl)phenyl))-2(5H)-furanone', u'NCGC00095118-02', u'NCGC00095118-03', u'NCGC00095118-04', u'AC-13144', u'CPD000466331', u'LS-70511', u'NCI60_041175', u'SAM001246617', u'SMR000466331', u'FT-0081390', u'C07590', u'D00568', u'L000912', u'186912-82-3', u'BRD-K21733600-001-02-6', u'I01-1042', u'3-phenyl-4-[4-(methylsulfonyl)phenyl]-2(5H)-furanone', u'4-(4-(Methylsulfonyl)phenyl)-3-phenylfuran-2(5H)-one', u'refecoxib', u'2(5H)-Furanone, 4-[4-(methyl-sulfonyl)phenyl]-3-phenyl-', u'Vioxx Dolor', u'MSD brand of rofecoxib', u'Merck brand of rofecoxib', u'2(5H)-Furanone, 4-[4-(methylsulfonyl)phenyl]-3-phenyl-', u'Merck Frosst brand of rofecoxib', u'CID5090', u'Rofecoxib (Vioxx)', u'Rofecoxib [USAN]', u'Cahill May Roberts brand of rofecoxib', u'Merck Sharp & Dhome brand of rofecoxib', u'PubChem15028', u'SureCN3050', u'DSSTox_CID_3567', u'AGN-PC-00E0TK', u'DSSTox_RID_77084', u'C116926', u'DSSTox_GSID_23567', u'Rofecoxib [USAN:INN:BAN]', u'GTPL2893', u'HMS2232G21', u'HMS3371P11', u'HMS3393G16', u'MK966', u'Pharmakon1600-01504235', u'Tox21_111430', u'ANW-71936', u'CCG-40253', u'DAP001338', u'NSC758705', u'AB07701', u'BD41342', u'CS-0997', u'MCULE-4806636118', u'NC00132', u'NSC-720256', u'NSC-758705', u'NCGC00095118-05', u'AK-60971', u'HY-17372', u'CAS-162011-90-7', u'FT-0631192', u'K-5064', u'AB00052090-06', u'AB00052090-08', u'A810324', u'3B2-0954', u'Rofecoxib|162011-90-7|Vioxx|MK966|MK-966', u'4-(4-METHANESULFONYL-PHENYL)-3-PHENYL-5H-FURAN-2-ONE', u'4-(4-methanesulfonylphenyl)-3-phenyl-2,5-dihydrofuran-2-one']\n"
+      "[u'rofecoxib', u'Vioxx', u'162011-90-7', u'Ceoxx', u'MK 966', u'4-[4-(methylsulfonyl)phenyl]-3-phenylfuran-2(5H)-one', u'4-(4-(Methylsulfonyl)phenyl)-3-phenylfuran-2(5H)-one', u'MK 0966', u'MK-966', u'4-[4-(methylsulfonyl)phenyl]-3-phenyl-2(5H)-furanone', u'MK-0966', u'UNII-0QTW8Z7MCR', u'3-(4-methylsulfonylphenyl)-4-phenyl-2H-furan-5-one', u'Vioxx (trademark)', u'MK0966', u'CCRIS 8967', u'Vioxx (TN)', u'HSDB 7262', u'MK 996', u'0QTW8Z7MCR', u'CHEMBL122', u'KS-1107', u'4-(4-methylsulfonylphenyl)-3-phenyl-5H-furan-2-one', u'Rofecoxib (JAN/USAN/INN)', u'3-phenyl-4-[4-(methylsulfonyl)phenyl]-2(5H)-furanone', u'4-(4-(Methylsulfonyl)phenyl)-3-phenyl-2(5H)-furanone', u'3-Phenyl-4-(4-(methylsulfonyl)phenyl))-2(5H)-furanone', u'CHEBI:8887', u'C17H14O4S', u'RZJQGNCSTQAWON-UHFFFAOYSA-N', u'4-(p-(Methylsulfonyl)phenyl)-3-phenyl-2(5H)-furanone', u'MK 0996', u'NCGC00095118-01', u'Vioxx-d5 (Major)', u'2(5H)-Furanone, 4-(4-(methylsulfonyl)phenyl)-3-phenyl-', u'2(5H)-Furanone, 4-[4-(methylsulfonyl)phenyl]-3-phenyl-', u'refecoxib', u'4-(4-METHANESULFONYL-PHENYL)-3-PHENYL-5H-FURAN-2-ONE', u'Vioxx Dolor', u'186912-82-3', u'SMR000466331', u'MSD brand of rofecoxib', u'Merck brand of rofecoxib', u'ceeoxx', u'rofecoxibum', u'Rofecoxib [USAN:INN:BAN]', u'Rofecoxib (Vioxx)', u'Ceeoxx (TN)', u'Cahill May Roberts brand of rofecoxib', u'Ceoxx (TN)', u'544684-93-7', u'Merck Sharp & Dhome brand of rofecoxib', u'PubChem15028', u'Spectrum_000119', u'SpecPlus_000669', u'Spectrum2_000446', u'Spectrum3_001153', u'Spectrum4_000631', u'Spectrum5_001598', u'DSSTox_CID_3567', u'D05VLS', u'AC1L1JL6', u'SCHEMBL3050', u'DSSTox_RID_77084', u'DSSTox_GSID_23567', u'BSPBio_002705', u'KBioGR_001242', u'KBioGR_002345', u'KBioSS_000559', u'KBioSS_002348', u'MLS000759440', u'MLS001165770', u'MLS001195623', u'MLS001424113', u'MLS006010091', u'BIDD:GT0399', u'Bio-0094', u'DivK1c_006765', u'Merck Frosst brandof rofecoxib', u'SPECTRUM1504235', u'SPBio_000492', u'3-(4-methanesulfonylphenyl)-2-phenyl-2-buten-4-olide', u'GTPL2893', u'ZINC7455', u'Jsp003237', u'DTXSID2023567', u'BDBM22369', u'KBio1_001709', u'KBio2_000559', u'KBio2_002345', u'KBio2_003127', u'KBio2_004913', u'KBio2_005695', u'KBio2_007481', u'KBio3_002205', u'KBio3_002825', u'KS-00000XKS', u'AOB6956', u'EX-A708', u'TRM-201', u'cMAP_000024', u'MolPort-000-883-878', u'MolPort-006-817-786', u'HMS1922H11', u'HMS2051G16', u'HMS2089H20', u'HMS2093E04', u'HMS2232G21', u'HMS3371P11', u'HMS3393G16', u'HMS3651F16', u'MK966', u'Pharmakon1600-01504235', u'EBD34785', u'Tox21_111430', u'ANW-71936', u'CCG-40253', u'MFCD00935806', u'NSC720256', u'NSC758705', u's3043', u'STK635144', u'AKOS000280931', u'AB07701', u'CS-0997', u'DB00533', u'MCULE-4806636118', u'NC00132', u'NSC-720256', u'NSC-758705', u'VA11689', u'NCGC00095118-02', u'NCGC00095118-03', u'NCGC00095118-04', u'NCGC00095118-05', u'AC-28318', u'AJ-08299', u'AK-60971', u'AN-25306', u'CPD000466331', u'DR001346', u'HE230410', u'HE320865', u'HY-17372', u'LS-70511', u'NCI60_041175', u'SAM001246617', u'SC-17320', u'ZB000656', u'SBI-0206774.P001', u'AB0012045', u'RT-016235', u'ST2410970', u'CAS-162011-90-7', u'FT-0081390', u'FT-0631192', u'C07590', u'D00568', u'J10420', u'K-5064', u'AB00052090-06', u'AB00052090-08', u'AB00052090_09', u'AB00052090_10', u'011R907', u'A810324', u'L000912', u'I01-1042', u'Q-201676', u'BRD-K21733600-001-02-6', u'3-(4-methanesulfonyl-phenyl)-2-phenyl-2-buten-4-olide', u'2(5H)-Furanone, 4-[4-(methyl-sulfonyl)phenyl]-3-phenyl-', u'3-(Phenyl)-4-(4-(methylsulfonyl)phenyl)-2-(5H)-furanone', u'3-Phenyl-4-(4-(Methylsulfonyl)Phenyl)-2-(5H)-Furanone', u'4-(4-methanesulfonylphenyl)-3-phenyl-2,5-dihydrofuran-2-one', u'Vioxx; 4-[4-(Methylsulfonyl)phenyl]-3-phenylfuran-2(5H)-one']\n"
      ]
     }
    ],
@@ -193,18 +177,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[Compound(5793), Compound(79025), Compound(64689), Compound(206)]"
+       "[Compound(5793)]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -223,19 +205,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O\n",
-      "C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O\n",
-      "C([C@@H]1[C@H]([C@@H]([C@H]([C@@H](O1)O)O)O)O)O\n",
-      "C(C1C(C(C(C(O1)O)O)O)O)O\n"
+      "C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O\n"
      ]
     }
    ],
@@ -255,10 +232,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -266,7 +241,7 @@
        "[Compound(1318)]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,6 +255,79 @@
    "metadata": {},
    "source": [
     "It's worth being aware that line notation inputs like SMILES and InChI can return automatically generated records that aren’t actually present in PubChem, and therefore have no CID and are missing many properties that are too complicated to calculate on the fly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Searching with entrez\n",
+    "\n",
+    "Running `get_compounds()` may not always return a result, for example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results = pcp.get_compounds('mouse tyrosinase', 'name')\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instead, you can run an  by using `find_compounds()`, for example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Compound(9919967)]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results = pcp.find_compounds('mouse tyrosinase', as_compounds=True)\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This function is simply a call to NCBI's E-utilities functionality which executes an [entrez query](https://www.ncbi.nlm.nih.gov/books/NBK3837/) on the PubChem database using the endpoint `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi`.\n",
+    "\n",
+    "The function `find_compounds()` can either return:\n",
+    "- a list of CIDs (by default)\n",
+    "- a list of `class Compound` (by passing `as_compound=True`)\n",
+    "- a Pandas DataFrame (by passing `as_dataframe=True`)\n",
+    "\n",
+    "Note that passing either `as_compound` or `as_dataframe` will make multiple calls to the NCBI server and could be slow based on the results from. It may also violate their usage policy:\n",
+    "> We ask that any script or application not make more than 5 requests per second, in order to avoid overloading the PubChem servers."
    ]
   },
   {
@@ -307,9 +355,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/pubchempy.py
+++ b/pubchempy.py
@@ -325,7 +325,7 @@ def find_compounds(identifier, as_dataframe=False, as_compounds=False, **kwargs)
     :return: by default, returns a list of CIDs matching the identifier string; if `as_compounds` is provided, the returned list will be a collection of :class:`~pubchempy.Compound`
     
     """
-    result = get(identifier, domain='eutils', namespace='term', output='XML')
+    result = get('"{}"'.format(identifier), domain='eutils', namespace='term', output='XML')
     e = ET.fromstring(result) # parse XML
     ids = [i.text for i in list(e.find('IdList'))] # grab matching IDs
 

--- a/pubchempy.py
+++ b/pubchempy.py
@@ -267,7 +267,7 @@ def request(identifier, namespace='cid', domain='compound', operation=None, outp
         apiurl = '/'.join(comps)
     else:
         apiurl = EUTILS_BASE
-        postdata += '&' + urlencode([('db', 'pccompound')]).encode('utf8')
+        postdata = urlencode([('db', 'pccompound'),(namespace, identifier)]).encode('utf8')
     if kwargs:
         apiurl += '?%s' % urlencode(kwargs)
     # Make request


### PR DESCRIPTION
`get_compounds()` may not always return any results, for example:
```python
results = pcp.get_compounds('mouse tyrosinase', 'name')
```
returns an empty list.

I propose a new function `find_compounds()` which leverages the e-utilities functionality to query the Pubchem database for any matching compound names; for example:
```python
results = pcp.find_compounds('mouse tyrosinase', as_compounds=True)
results
```
will return `[Compound(9919967)]`

It works by using the `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi` endpoint along with `?db=pccompound&term=<query term>` as POST data.