### PR TITLE
Add support for fastidentity searchtype to enhance search capabilities

### DIFF
--- a/pubchempy.py
+++ b/pubchempy.py
@@ -277,7 +277,11 @@ def request(identifier, namespace='cid', domain='compound', operation=None, outp
 def get(identifier, namespace='cid', domain='compound', operation=None, output='JSON', searchtype=None, **kwargs):
     """Request wrapper that automatically handles async requests."""
     if (searchtype and searchtype != 'xref') or namespace in ['formula']:
-        response = request(identifier, namespace, domain, None, 'JSON', searchtype, **kwargs).read()
+        # BalooRM - if searchtype == 'fastidentity', pass operation in place of None
+        if searchtype == 'fastidentity':
+            response = request(identifier, namespace, domain, operation, 'JSON', searchtype, **kwargs).read()
+        else:
+            response = request(identifier, namespace, domain, None, 'JSON', searchtype, **kwargs).read()            
         status = json.loads(response.decode())
         if 'Waiting' in status and 'ListKey' in status['Waiting']:
             identifier = status['Waiting']['ListKey']


### PR DESCRIPTION
The PubChem REST API fastidentity searchtype includes support for search by SMILES string to identify multiple stereoisomers of the same canonical SMILES string. A simple if: else: construct was added to the PubChemPy get() function to pass the operation value, thus enabling synchronous ("fast") input searches. (https://pubchemdocs.ncbi.nlm.nih.gov/pug-rest). 

This was tested for the get_compounds() and get_cids() functions and found to perform as expected to return multiple isomers by canonical SMILES search. 

PubChem "fast" searches cover several types, in addition to the fastidentity search, and may similarly be supported by changing the equality test to a test for presence of the searchtype in a list. This is beyond the scope of this pull request but may require little effort to implement. 

The code change preserves the original result = request() expression in the else: clause and places the modified call, which includes the operation (in place of None in the original call), in the if (True): clause. 
