### PR TITLE
update print instructions in the documentation

### DIFF
--- a/docs/source/guide/contribute.rst
+++ b/docs/source/guide/contribute.rst
@@ -18,6 +18,7 @@ Contributors
 - |ghi| `llazzaro <https://github.com/llazzaro>`_ (Leonardo Lazzaro)
 - |ghi| `bjodah <https://github.com/bjodah>`_ (Björn Dahlgren)
 - |ghi| `RickardSjogren <https://github.com/RickardSjogren>`_ (Rickard Sjögren)
+- |ghi| `nbehrnd <https://github.com/nbehrnd>`_ (Norwid Behrnd)
 
 .. _`source code`: https://github.com/mcs07/PubChemPy
 .. _`Issue Tracker`: https://github.com/mcs07/PubChemPy/issues

--- a/docs/source/guide/gettingstarted.rst
+++ b/docs/source/guide/gettingstarted.rst
@@ -22,17 +22,17 @@ Let's get the Compound with `CID 5090`_::
 Now we have a :class:`~pubchempy.Compound` object called ``c``. We can get all the information we need from this
 object::
 
-    >>> print c.molecular_formula
+    >>> print(c.molecular_formula)
     C17H14O4S
-    >>> print c.molecular_weight
-    314.35566
-    >>> print c.isomeric_smiles
+    >>> print(c.molecular_weight)
+    314.4
+    >>> print(c.isomeric_smiles)
     CS(=O)(=O)C1=CC=C(C=C1)C2=C(C(=O)OC2)C3=CC=CC=C3
-    >>> print c.xlogp
+    >>> print(c.xlogp)
     2.3
-    >>> print c.iupac_name
+    >>> print(c.iupac_name)
     3-(4-methylsulfonylphenyl)-4-phenyl-2H-furan-5-one
-    >>> print c.synonyms
+    >>> print(c.synonyms)
     [u'rofecoxib', u'Vioxx', u'Ceoxx', u'162011-90-7', u'MK 966', ... ]
 
 .. note::
@@ -51,19 +51,16 @@ What if you don't know the PubChem CID of the Compound you want? Just use the :f
 function::
 
     >>> results = pcp.get_compounds('Glucose', 'name')
-    >>> print results
-    [Compound(79025), Compound(5793), Compound(64689), Compound(206)]
+    >>> print(results)
+    [Compound(5793)]
 
 The first argument is the identifier, and the second argument is the identifier type, which must be one of ``name``,
 ``smiles``, ``sdf``, ``inchi``, ``inchikey`` or ``formula``. It looks like there are 4 compounds in the PubChem
 Database that have the name Glucose associated with them. Let's take a look at them in more detail::
 
     >>> for compound in results:
-    ...    print compound.isomeric_smiles
-    C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O
+    ...    print(compound.isomeric_smiles)
     C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O
-    C([C@@H]1[C@H]([C@@H]([C@H]([C@@H](O1)O)O)O)O)O
-    C(C1C(C(C(C(O1)O)O)O)O)O
 
 It looks like they all have different stereochemistry information.
 

--- a/docs/source/guide/substance.rst
+++ b/docs/source/guide/substance.rst
@@ -17,18 +17,18 @@ Retrieving substances
 Retrieve Substances using the :func:`~pubchempy.get_substances` function::
 
     >>> results = pcp.get_substances('Coumarin 343', 'name')
-    >>> print results
-    [Substance(24864499), Substance(85084977), Substance(126686397), Substance(143491255), Substance(152243230), Substance(162092514), Substance(162189467), Substance(186021999), Substance(206257050)]
+    >>> print(results)
+    [Substance(24864499), Substance(85084977), Substance(126686397), Substance(143491255), Substance(152243230), Substance(162092514), Substance(162189467), Substance(186021999), Substance(206257050), ... ]
 
 
 You can also instantiate a Substance directly from its SID::
 
     >>> substance = pcp.Substance.from_sid(223766453)
-    >>> print substance.synonyms
+    >>> print(substance.synonyms)
     ['2-(Acetyloxy)-benzoic acid', '2-(acetyloxy)benzoic acid', '2-acetoxy benzoic acid', '2-acetoxy-benzoic acid', '2-acetoxybenzoic acid', '2-acetyloxybenzoic acid', 'BSYNRYMUTXBXSQ-UHFFFAOYSA-N', 'acetoxybenzoic acid', 'acetyl salicylic acid', 'acetyl-salicylic acid', 'acetylsalicylic acid', 'aspirin', 'o-acetoxybenzoic acid']
-    >>> print substance.source_id
+    >>> print(substance.source_id)
     BSYNRYMUTXBXSQ-UHFFFAOYSA-N
-    >>> print substance.standardized_cid
+    >>> print(substance.standardized_cid)
     2244
-    >>> print substance.standardized_compound
+    >>> print(substance.standardized_compound)
     Compound(2244)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,15 +13,15 @@ retrieval of chemical properties.
 Here's a quick example showing how to search for a compound by name::
 
     for compound in get_compounds('glucose', 'name'):
-        print compound.cid
-        print compound.isomeric_smiles
+        print(compound.cid)
+        print(compound.isomeric_smiles)
 
 Here's how you get calculated properties for a specific compound::
 
     vioxx = Compound.from_cid(5090)
-    print vioxx.molecular_formula
-    print vioxx.molecular_weight
-    print vioxx.xlogp
+    print(vioxx.molecular_formula)
+    print(vioxx.molecular_weight)
+    print(vioxx.xlogp)
 
 All the heavy lifting is done by PubChem's servers, using their database and chemical toolkits.
 
@@ -37,7 +37,7 @@ Features
 - Download compound records as XML, ASNT/B, JSON, SDF and depiction as a PNG image.
 - Construct property tables using *pandas* DataFrames.
 - A complete Python wrapper around the `PubChem PUG REST web service`_.
-- Supports Python versions 2.7 – 3.4.
+- Supports Python versions 2.7 – 3.9.
 
 
 Useful links


### PR DESCRIPTION
By the previous commmit, the documentation still included the
old Python2 print statement.  It has been superseeded by Python3's
print function this commit adopts.  On occasion, the results
querring the PubChem database differ from the earlier version of
the documentation which are considered, too.

A check run of the functionality described by the documentation
(except for code in advanced.rst, not tested) with Python 3.9.2,
pandas 1.3.1, jupyter-notebook 6.2.0, PubChemPy 1.0.4 in Linux
Debian 11/bullseye, branch testing, was successful.