### PR TITLE
update/adjustment of notebooks to Python 3

### DIFF
--- a/examples/1-introduction.ipynb
+++ b/examples/1-introduction.ipynb
@@ -20,23 +20,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "5793\n",
-      "C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O\n",
-      "79025\n",
-      "C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O\n",
-      "64689\n",
-      "C([C@@H]1[C@H]([C@@H]([C@H]([C@@H](O1)O)O)O)O)O\n",
-      "206\n",
-      "C(C1C(C(C(C(O1)O)O)O)O)O\n"
+      "C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O\n"
      ]
     }
    ],
@@ -65,17 +57,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "C17H14O4S\n",
-      "314.35566\n",
+      "314.4\n",
       "2.3\n"
      ]
     }
@@ -84,9 +74,9 @@
     "from pubchempy import Compound\n",
     "\n",
     "vioxx = Compound.from_cid(5090)\n",
-    "print vioxx.molecular_formula\n",
-    "print vioxx.molecular_weight\n",
-    "print vioxx.xlogp"
+    "print(vioxx.molecular_formula)\n",
+    "print(vioxx.molecular_weight)\n",
+    "print(vioxx.xlogp)"
    ]
   },
   {
@@ -109,23 +99,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/2-getting-started.ipynb
+++ b/examples/2-getting-started.ipynb
@@ -23,9 +23,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pubchempy as pcp"
@@ -40,10 +38,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -51,7 +47,7 @@
        "Compound(5090)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -70,10 +66,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -89,16 +83,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "314.35566\n"
+      "314.4\n"
      ]
     }
    ],
@@ -108,10 +100,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -127,10 +117,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -146,10 +134,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -165,16 +151,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[u'rofecoxib', u'Vioxx', u'Ceoxx', u'162011-90-7', u'MK 966', u'MK-966', u'4-[4-(methylsulfonyl)phenyl]-3-phenylfuran-2(5H)-one', u'MK-0966', u'Vioxx (trademark)', u'MK 0966', u'CCRIS 8967', u'CHEBI:8887', u'Vioxx (TN)', u'HSDB 7262', u'Spectrum_000119', u'SpecPlus_000669', u'Spectrum2_000446', u'Spectrum3_001153', u'Spectrum4_000631', u'Spectrum5_001598', u'UNII-0QTW8Z7MCR', u'MK 996', u'MK0966', u'CHEMBL122', u'AC1L1JL6', u'KS-1107', u'3-(4-methylsulfonylphenyl)-4-phenyl-2H-furan-5-one', u'4-(4-methylsulfonylphenyl)-3-phenyl-5H-furan-2-one', u'NCGC00095118-01', u'BSPBio_002705', u'KBioGR_001242', u'KBioGR_002345', u'KBioSS_000559', u'KBioSS_002348', u'Rofecoxib (JAN/USAN/INN)', u'BIDD:GT0399', u'Bio-0094', u'DivK1c_006765', u'4-[4-(methylsulfonyl)phenyl]-3-phenyl-2(5H)-furanone', u'SPBio_000492', u'SPECTRUM1504235', u'MLS000759440', u'MLS001165770', u'MLS001195623', u'MLS001424113', u'Jsp003237', u'C17H14O4S', u'KBio1_001709', u'KBio2_000559', u'KBio2_002345', u'KBio2_003127', u'KBio2_004913', u'KBio2_005695', u'KBio2_007481', u'KBio3_002205', u'KBio3_002825', u'cMAP_000024', u'MolPort-000-883-878', u'MolPort-006-817-786', u'HMS1922H11', u'HMS2051G16', u'HMS2089H20', u'HMS2093E04', u'NSC720256', u'STK635144', u'ZINC00007455', u'AKOS000280931', u'4-(4-(Methylsulfonyl)phenyl)-3-phenyl-2(5H)-furanone', u'4-(p-(Methylsulfonyl)phenyl)-3-phenyl-2(5H)-furanone', u'DB00533', u'MK 0996', u'2(5H)-Furanone, 4-(4-(methylsulfonyl)phenyl)-3-phenyl-', u'3-Phenyl-4-(4-(methylsulfonyl)phenyl))-2(5H)-furanone', u'NCGC00095118-02', u'NCGC00095118-03', u'NCGC00095118-04', u'AC-13144', u'CPD000466331', u'LS-70511', u'NCI60_041175', u'SAM001246617', u'SMR000466331', u'FT-0081390', u'C07590', u'D00568', u'L000912', u'186912-82-3', u'BRD-K21733600-001-02-6', u'I01-1042', u'3-phenyl-4-[4-(methylsulfonyl)phenyl]-2(5H)-furanone', u'4-(4-(Methylsulfonyl)phenyl)-3-phenylfuran-2(5H)-one', u'refecoxib', u'2(5H)-Furanone, 4-[4-(methyl-sulfonyl)phenyl]-3-phenyl-', u'Vioxx Dolor', u'MSD brand of rofecoxib', u'Merck brand of rofecoxib', u'2(5H)-Furanone, 4-[4-(methylsulfonyl)phenyl]-3-phenyl-', u'Merck Frosst brand of rofecoxib', u'CID5090', u'Rofecoxib (Vioxx)', u'Rofecoxib [USAN]', u'Cahill May Roberts brand of rofecoxib', u'Merck Sharp & Dhome brand of rofecoxib', u'PubChem15028', u'SureCN3050', u'DSSTox_CID_3567', u'AGN-PC-00E0TK', u'DSSTox_RID_77084', u'C116926', u'DSSTox_GSID_23567', u'Rofecoxib [USAN:INN:BAN]', u'GTPL2893', u'HMS2232G21', u'HMS3371P11', u'HMS3393G16', u'MK966', u'Pharmakon1600-01504235', u'Tox21_111430', u'ANW-71936', u'CCG-40253', u'DAP001338', u'NSC758705', u'AB07701', u'BD41342', u'CS-0997', u'MCULE-4806636118', u'NC00132', u'NSC-720256', u'NSC-758705', u'NCGC00095118-05', u'AK-60971', u'HY-17372', u'CAS-162011-90-7', u'FT-0631192', u'K-5064', u'AB00052090-06', u'AB00052090-08', u'A810324', u'3B2-0954', u'Rofecoxib|162011-90-7|Vioxx|MK966|MK-966', u'4-(4-METHANESULFONYL-PHENYL)-3-PHENYL-5H-FURAN-2-ONE', u'4-(4-methanesulfonylphenyl)-3-phenyl-2,5-dihydrofuran-2-one']\n"
+      "['rofecoxib', '162011-90-7', 'Vioxx', 'Ceoxx', 'MK 966', '4-(4-(Methylsulfonyl)phenyl)-3-phenylfuran-2(5H)-one', '4-[4-(methylsulfonyl)phenyl]-3-phenylfuran-2(5H)-one', 'MK-966', 'MK 0966', 'MK-0966', '4-[4-(methylsulfonyl)phenyl]-3-phenyl-2(5H)-furanone', 'MK0966', '3-(4-methylsulfonylphenyl)-4-phenyl-2H-furan-5-one', 'UNII-0QTW8Z7MCR', 'Rofecoxib (Vioxx)', 'C17H14O4S', '3-phenyl-4-[4-(methylsulfonyl)phenyl]-2(5H)-furanone', '0QTW8Z7MCR', 'CHEMBL122', '4-(4-(Methylsulfonyl)phenyl)-3-phenyl-2(5H)-furanone', 'CHEBI:8887', 'TRM-201', '2(5H)-Furanone, 4-[4-(methylsulfonyl)phenyl]-3-phenyl-', 'refecoxib', 'NCGC00095118-01', '4-(4-methanesulfonylphenyl)-3-phenyl-2,5-dihydrofuran-2-one', 'Vioxx Dolor', '2(5H)-Furanone, 4-(4-(methylsulfonyl)phenyl)-3-phenyl-', 'Vioxx (trademark)', 'SMR000466331', 'CCRIS 8967', 'Vioxx (TN)', 'HSDB 7262', 'SR-01000762904', 'rofecoxibum', 'Rofecoxib (JAN/USAN/INN)', 'Rofecoxib [USAN:INN:BAN]', '3-Phenyl-4-(4-(methylsulfonyl)phenyl))-2(5H)-furanone', 'MK966', '4-(4-methylsulfonylphenyl)-3-phenyl-5H-furan-2-one', '4-(p-(Methylsulfonyl)phenyl)-3-phenyl-2(5H)-furanone', 'KS-1107', 'MK 0996', 'Spectrum_000119', 'SpecPlus_000669', 'Spectrum2_000446', 'Spectrum3_001153', 'Spectrum4_000631', 'Spectrum5_001598', 'DSSTox_CID_3567', 'SCHEMBL3050', 'DSSTox_RID_77084', 'DSSTox_GSID_23567', 'BSPBio_002705', 'KBioGR_001242', 'KBioGR_002345', 'KBioSS_000559', 'KBioSS_002348', 'MLS000759440', 'MLS001165770', 'MLS001195623', 'MLS001424113', 'MLS006010091', 'BIDD:GT0399', 'DivK1c_006765', 'SPECTRUM1504235', 'SPBio_000492', '3-(4-methanesulfonylphenyl)-2-phenyl-2-buten-4-olide', 'GTPL2893', 'ZINC7455', 'DTXSID2023567', 'BDBM22369', 'KBio1_001709', 'KBio2_000559', 'KBio2_002345', 'KBio2_003127', 'KBio2_004913', 'KBio2_005695', 'KBio2_007481', 'KBio3_002205', 'KBio3_002825', 'AOB6956', 'EX-A708', 'M01AH02', 'cMAP_000024', 'HMS1922H11', 'HMS2051G16', 'HMS2089H20', 'HMS2093E04', 'HMS2232G21', 'HMS3371P11', 'HMS3393G16', 'HMS3651F16', 'HMS3713B07', 'HMS3750I17', 'HMS3885E05', 'Pharmakon1600-01504235', 'BCP03619', 'EBD34785', 'Tox21_111430', 'CCG-40253', 'MFCD00935806', 'NSC720256', 'NSC758705', 's3043', 'STK635144', 'AKOS000280931', 'AB07701', 'CS-0997', 'DB00533', 'MCULE-4806636118', 'NC00132', 'NSC 720256', 'NSC 758705', 'NSC-720256', 'NSC-758705', 'SB19518', 'VA11689', 'NCGC00095118-02', 'NCGC00095118-03', 'NCGC00095118-04', 'NCGC00095118-05', 'NCGC00095118-08', 'NCGC00095118-17', 'NCGC00095118-18', 'AC-28318', 'BR164362', 'HY-17372', 'NCI60_041175', 'SBI-0206774.P001', 'AB0012045', 'CAS-162011-90-7', 'FT-0631192', 'R0206', 'SW219668-1', 'C07590', 'D00568', 'J10420', 'AB00052090-06', 'AB00052090-08', 'AB00052090_09', 'AB00052090_10', '011R907', 'A810324', 'L000912', 'Q411412', 'Q-201676', 'SR-01000762904-3', 'SR-01000762904-5', 'BRD-K21733600-001-02-6', 'BRD-K21733600-001-06-7', '3-(4-methanesulfonyl-phenyl)-2-phenyl-2-buten-4-olide', '2(5H)-Furanone, 4-[4-(methyl-sulfonyl)phenyl]-3-phenyl-', '3-(Phenyl)-4-(4-(methylsulfonyl)phenyl)-2-(5H)-furanone', '3-Phenyl-4-(4-(Methylsulfonyl)Phenyl)-2-(5H)-Furanone', '4-(4-METHANESULFONYL-PHENYL)-3-PHENYL-5H-FURAN-2-ONE', '4-(4-methylsulfonylphenyl)-3-phenyl-2,5-dihydro-2-furanone', 'Vioxx; 4-[4-(Methylsulfonyl)phenyl]-3-phenylfuran-2(5H)-one']\n"
      ]
     }
    ],
@@ -193,18 +177,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[Compound(5793), Compound(79025), Compound(64689), Compound(206)]"
+       "[Compound(5793)]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -223,25 +205,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O\n",
-      "C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O)O)O)O)O\n",
-      "C([C@@H]1[C@H]([C@@H]([C@H]([C@@H](O1)O)O)O)O)O\n",
-      "C(C1C(C(C(C(O1)O)O)O)O)O\n"
+      "C([C@@H]1[C@H]([C@@H]([C@H](C(O1)O)O)O)O)O\n"
      ]
     }
    ],
    "source": [
     "for compound in results:\n",
-    "    print compound.isomeric_smiles"
+    "    print(compound.isomeric_smiles)"
    ]
   },
   {
@@ -255,22 +232,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Compound(1318)]"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "pcp.get_compounds('C1=CC2=C(C3=C(C=CC=N3)C=C2)N=C1', 'smiles')"
    ]
@@ -293,23 +257,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/CAS registry numbers.ipynb
+++ b/examples/CAS registry numbers.ipynb
@@ -10,9 +10,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import re\n",
@@ -29,9 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import logging\n",
@@ -49,9 +45,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def get_substructure_cas(smiles):\n",
@@ -75,26 +69,14 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/substructure/smiles/JSON\n",
-      "DEBUG:pubchempy:Request data: smiles=%5BPb%5D\n",
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/listkey/3178699647975629202/synonyms/JSON\n",
-      "DEBUG:pubchempy:Request data: None\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2174\n",
-      "[u'7439-92-1', u'15875-18-0', u'54076-28-7', u'14701-27-0', u'15158-12-0', u'52229-97-7', u'724427-66-1', u'598-63-0', u'13427-42-4', u'17398-75-3']\n"
+      "856\n",
+      "['7439-92-1', '54076-28-7', '14452-81-4', '1317-36-8', '79120-33-5', '78-00-2', '10099-74-8', '301-04-2', '1314-87-0', '12179-39-4']\n"
      ]
     }
    ],
@@ -107,28 +89,14 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/substructure/smiles/JSON\n",
-      "DEBUG:pubchempy:Request data: smiles=%5BSe%5D\n",
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/listkey/852509384123203131/synonyms/JSON\n",
-      "DEBUG:pubchempy:Request data: None\n",
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/listkey/852509384123203131/synonyms/JSON\n",
-      "DEBUG:pubchempy:Request data: None\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "14577\n",
-      "[u'10102-18-8', u'26970-82-1', u'15498-87-0', u'7782-82-3', u'14013-56-0', u'14013-56-0', u'29528-97-0', u'50647-14-8', u'7782-49-2', u'11125-23-8']\n"
+      "3672\n",
+      "['7783-00-8', '10102-18-8', '10102-18-8', '14013-56-0', '1464-42-2', '2578-28-1', '7782-49-2', '630-10-4', '60940-34-3', '7446-08-4']\n"
      ]
     }
    ],
@@ -141,26 +109,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/substructure/smiles/JSON\n",
-      "DEBUG:pubchempy:Request data: smiles=%5BTi%5D\n",
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/listkey/1812119792714669902/synonyms/JSON\n",
-      "DEBUG:pubchempy:Request data: None\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1630\n",
-      "[u'13463-67-7', u'1317-80-2', u'1317-70-0', u'98084-96-9', u'100292-32-8', u'101239-53-6', u'116788-85-3', u'12000-59-8', u'12036-20-3', u'12701-76-7']\n"
+      "875\n",
+      "['13463-67-7', '1317-70-0', '1317-80-2', '98084-96-9', '7440-32-6', '14067-04-0', '546-68-9', '68585-67-1', '1271-19-8', '12035-95-9']\n"
      ]
     }
    ],
@@ -173,26 +129,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/substructure/smiles/JSON\n",
-      "DEBUG:pubchempy:Request data: smiles=%5BPd%5D\n",
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/listkey/2802290965277166497/synonyms/JSON\n",
-      "DEBUG:pubchempy:Request data: None\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1401\n",
-      "[u'7440-05-3', u'17637-99-9', u'53092-86-7', u'7647-10-1', u'10038-97-8', u'10102-05-3', u'14846-30-1', u'884739-77-9', u'3375-31-3', u'19807-27-3']\n"
+      "846\n",
+      "['7647-10-1', '7440-05-3', '19168-23-1', '10025-98-6', '13782-33-7', '14323-43-4', '16919-73-6', '12125-22-3', '3375-31-3', '19807-27-3']\n"
      ]
     }
    ],
@@ -212,30 +156,15 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/substructure/smiles/JSON\n",
-      "DEBUG:pubchempy:Request data: smiles=%5BPd%5D\n",
-      "DEBUG:pubchempy:Request URL: https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/listkey/3838589667186536348/cids/JSON\n",
-      "DEBUG:pubchempy:Request data: None\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "cids = pcp.get_cids('[Pd]', 'smiles', searchtype='substructure')"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "Then you can do `pcp.get_synonyms(cids)` with the list of CIDs."
    ]
@@ -243,23 +172,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/Chemical fingerprints and similarity.ipynb
+++ b/examples/Chemical fingerprints and similarity.ipynb
@@ -9,10 +9,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pubchempy as pcp\n",
@@ -28,10 +26,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 2,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -42,7 +38,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -54,10 +50,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -68,7 +62,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -80,10 +74,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -94,7 +86,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -106,10 +98,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -120,7 +110,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -141,18 +131,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "u'0000037180703000000000000000000000000000000000000000304000000000000000810000001A00000000000C04809800300E80000400880220D208000208002020000888000608C80C262284311A823A20A4C01108A98780C0200E00000000000800000000000000100000000000000000'"
+       "'0000037180703000000000000000000000000000000000000000304000000000000000810000001A00000000000C04809800300E80000400880220D208000208002020000888000608C80C262284311A823A20A4C01108A98780C0200E00000000000800000000000000100000000000000000'"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -170,10 +158,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -181,7 +167,7 @@
        "'0b1101110001100000000111000000110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011000001000000000000000000000000000000000000000000000000000000000000001000000100000000000000000000000000011010000000000000000000000000000000000000000000001100000001001000000010011000000000000011000000001110100000000000000000000100000000001000100000000010001000001101001000001000000000000000001000001000000000000010000000100000000000000000100010001000000000000000011000001000110010000000110000100110001000101000010000110001000110101000001000111010001000001010010011000000000100010000100010101001100001111000000011000000001000000000111000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -207,10 +193,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def tanimoto(compound1, compound2):\n",
@@ -231,10 +215,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -242,7 +224,7 @@
        "1.0"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -253,10 +235,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -264,7 +244,7 @@
        "0.6011904761904762"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -275,10 +255,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -286,7 +264,7 @@
        "0.6011904761904762"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -297,10 +275,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -308,7 +284,7 @@
        "0.9529411764705882"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -319,10 +295,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -330,7 +304,7 @@
        "0.8211382113821138"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -341,10 +315,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 14,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -352,7 +324,7 @@
        "0.6123595505617978"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -374,32 +346,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Running Linux Debian 12/bookworm (branch testing), I found some of the
notebooks still anticipating legacy Python 2; e.g., using `print` as a
statement instead as a function, or anticipating an old Python 2
kernel.

All four notebooks were checked; where necessary, adjusted.  They work
fine within Jupyter (version 6.4.5) backed by Python (version 3.9.9).