### PR TITLE
API Change for SMILES types

### DIFF
--- a/pubchempy.py
+++ b/pubchempy.py
@@ -829,13 +829,26 @@ class Compound(object):
 
     @property
     def canonical_smiles(self):
-        """Canonical SMILES, with no stereochemistry information."""
-        return _parse_prop({'label': 'SMILES', 'name': 'Canonical'}, self.record['props'])
+        """Canonical SMILES, with no stereochemistry information.
+            This was replaced with the Connectivity SMILES
+        """
+        return self.connectivity_smiles
 
     @property
     def isomeric_smiles(self):
-        """Isomeric SMILES."""
-        return _parse_prop({'label': 'SMILES', 'name': 'Isomeric'}, self.record['props'])
+        """Isomeric SMILES.
+            This was replaced with the Absolute SMILES"""
+        return self.absolute_smiles
+
+    @property
+    def connectivity_smiles(self):
+        """Connectivity SMILES, with no stereochemistry information."""
+        return _parse_prop({'label': 'SMILES', 'name': 'Connectivity'}, self.record['props'])
+
+    @property
+    def absolute_smiles(self):
+        """Absolute SMILES."""
+        return _parse_prop({'label': 'SMILES', 'name': 'Absolute'}, self.record['props'])
 
     @property
     def inchi(self):


### PR DESCRIPTION
Fixes #101 

Sometime in 2025, the PubChem API changed the way it handles SMILES strings.

From the glossary: https://pubchem.ncbi.nlm.nih.gov/docs/glossary#section=SMILES

The former "Canonical SMILES" property in our compound records has been replaced by a newly-named "Connectivity SMILES"