### PR TITLE
Rate-limit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Pytest configuration for PubChemPy tests."""
+
+import time
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def rate_limit_tests():
+    """Limit the rate of requests to PubChem.
+
+    This fixture ensures that there is a delay between tests to avoid hitting
+    PubChem's rate limits, which can cause PubChemHTTPError: 'PUGREST.ServerBusy' to be
+    raised. A delay of 1 second is automatically applied between every test.
+    """
+    yield
+    time.sleep(1)


### PR DESCRIPTION
Longer term I hope to add rate-limiting into the PubChemPy client itself, so this is just a temporary measure to ensure tests pass reliably.