### PR TITLE
Formatting and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,8 @@ repos:
       - id: ruff-check
         args:
           - --fix
-          - --select I
+          - --select
+          - I
           - --exit-non-zero-on-fix
       - id: ruff-format
 
@@ -32,6 +33,6 @@ repos:
     hooks:
       - id: nb-clean
         args:
-            - --remove-empty-cells
-            - --remove-all-notebook-metadata
-            - --preserve-cell-outputs
+          - --remove-empty-cells
+          - --remove-all-notebook-metadata
+          - --preserve-cell-outputs

--- a/examples/1-introduction.ipynb
+++ b/examples/1-introduction.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -35,7 +35,7 @@
    "source": [
     "from pubchempy import get_compounds\n",
     "\n",
-    "for compound in get_compounds('glucose', 'name'):\n",
+    "for compound in get_compounds(\"glucose\", \"name\"):\n",
     "    print(compound.cid)\n",
     "    print(compound.smiles)"
    ]
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -97,25 +97,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "pubchempy (3.12.11)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.11"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 1
 }

--- a/examples/2-getting-started.ipynb
+++ b/examples/2-getting-started.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -47,7 +47,7 @@
        "Compound(5090)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -186,13 +186,13 @@
        "[Compound(16051935)]"
       ]
      },
-     "execution_count": 37,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "results = pcp.get_compounds('Morphine sulfate', 'name')\n",
+    "results = pcp.get_compounds(\"Morphine sulfate\", \"name\")\n",
     "results"
    ]
   },
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -236,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pcp.get_compounds('C1=CC2=C(C3=C(C=CC=N3)C=C2)N=C1', 'smiles')"
+    "pcp.get_compounds(\"C1=CC2=C(C3=C(C=CC=N3)C=C2)N=C1\", \"smiles\")"
    ]
   },
   {
@@ -255,25 +255,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "pubchempy (3.12.11)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.11"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 1
 }

--- a/examples/CAS registry numbers.ipynb
+++ b/examples/CAS registry numbers.ipynb
@@ -11,12 +11,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import time\n",
     "import re\n",
+    "import time\n",
+    "\n",
     "import pubchempy as pcp"
    ]
   },
@@ -39,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +48,7 @@
     "    \"\"\"Filter a list of synonyms to just those that look like CAS registry numbers.\"\"\"\n",
     "    cas_rns = []\n",
     "    for syn in synonyms:\n",
-    "        match = re.match(r'(\\d{2,7}-\\d\\d-\\d)', syn)\n",
+    "        match = re.match(r\"(\\d{2,7}-\\d\\d-\\d)\", syn)\n",
     "        if match:\n",
     "            cas_rns.append(match.group(1))\n",
     "    return cas_rns"
@@ -62,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -75,9 +76,9 @@
    ],
    "source": [
     "for result in pcp.get_synonyms(2242):\n",
-    "    cid = result['CID']\n",
-    "    cas_rns = filter_cas_rns(result.get('Synonym', []))\n",
-    "    print(f'CAS registry numbers for CID {cid}: {cas_rns}')"
+    "    cid = result[\"CID\"]\n",
+    "    cas_rns = filter_cas_rns(result.get(\"Synonym\", []))\n",
+    "    print(f\"CAS registry numbers for CID {cid}: {cas_rns}\")"
    ]
   },
   {
@@ -89,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -104,9 +105,9 @@
    ],
    "source": [
     "for result in pcp.get_synonyms([2242, 134601, 6992065]):\n",
-    "    cid = result['CID']\n",
-    "    cas_rns = filter_cas_rns(result.get('Synonym', []))\n",
-    "    print(f'CAS registry numbers for CID {cid}: {cas_rns}')"
+    "    cid = result[\"CID\"]\n",
+    "    cas_rns = filter_cas_rns(result.get(\"Synonym\", []))\n",
+    "    print(f\"CAS registry numbers for CID {cid}: {cas_rns}\")"
    ]
   },
   {
@@ -118,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -132,7 +133,7 @@
    "source": [
     "compound = pcp.Compound.from_cid(2242)\n",
     "cas_rns = filter_cas_rns(compound.synonyms)\n",
-    "print(f'CAS registry numbers for CID 2242: {cas_rns}')"
+    "print(f\"CAS registry numbers for CID 2242: {cas_rns}\")"
    ]
   },
   {
@@ -144,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -166,10 +167,12 @@
    ],
    "source": [
     "count = 0\n",
-    "for result in pcp.get_synonyms('COC(=O)C(CC1=CC=CC=C1)NC(=O)C(CC(=O)O)N', 'smiles', searchtype='substructure'):\n",
-    "    cid = result['CID']\n",
-    "    cas_rns = filter_cas_rns(result.get('Synonym', []))\n",
-    "    print(f'CAS registry numbers for CID {cid}: {cas_rns}')\n",
+    "for result in pcp.get_synonyms(\n",
+    "    \"COC(=O)C(CC1=CC=CC=C1)NC(=O)C(CC(=O)O)N\", \"smiles\", searchtype=\"substructure\"\n",
+    "):\n",
+    "    cid = result[\"CID\"]\n",
+    "    cas_rns = filter_cas_rns(result.get(\"Synonym\", []))\n",
+    "    print(f\"CAS registry numbers for CID {cid}: {cas_rns}\")\n",
     "    count += 1\n",
     "    if count >= 10:\n",
     "        break"
@@ -184,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -225,41 +228,23 @@
     }
    ],
    "source": [
-    "cids = pcp.get_cids('[Pd]', 'smiles', searchtype='substructure')\n",
+    "cids = pcp.get_cids(\"[Pd]\", \"smiles\", searchtype=\"substructure\")\n",
     "batch_size = 5\n",
     "for i in range(0, len(cids), batch_size):\n",
-    "    batch = cids[i:i + batch_size]\n",
-    "    print(f'Getting synonyms for batch: {batch}')\n",
+    "    batch = cids[i : i + batch_size]\n",
+    "    print(f\"Getting synonyms for batch: {batch}\")\n",
     "    results = pcp.get_synonyms(batch)\n",
     "    for result in results:\n",
-    "        cid = result['CID']\n",
-    "        cas_rns = filter_cas_rns(result.get('Synonym', []))\n",
-    "        print(f'CAS registry numbers for CID {cid}: {cas_rns}')\n",
+    "        cid = result[\"CID\"]\n",
+    "        cas_rns = filter_cas_rns(result.get(\"Synonym\", []))\n",
+    "        print(f\"CAS registry numbers for CID {cid}: {cas_rns}\")\n",
     "    time.sleep(1)  # Respect PubChem's rate limits\n",
     "    if i >= 20:\n",
     "        break"
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "pubchempy (3.12.11)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.11"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/examples/Chemical fingerprints and similarity.ipynb
+++ b/examples/Chemical fingerprints and similarity.ipynb
@@ -9,12 +9,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pubchempy as pcp\n",
-    "from IPython.display import Image"
+    "from IPython.display import Image\n",
+    "\n",
+    "import pubchempy as pcp"
    ]
   },
   {
@@ -26,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -38,19 +39,19 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "coumarin = pcp.Compound.from_cid(323)\n",
-    "Image(url='https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=323&t=l')"
+    "Image(url=\"https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=323&t=l\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -62,19 +63,19 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "coumarin_314 = pcp.Compound.from_cid(72653)\n",
-    "Image(url='https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=72653&t=l')"
+    "Image(url=\"https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=72653&t=l\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -86,19 +87,19 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "coumarin_343 = pcp.Compound.from_cid(108770)\n",
-    "Image(url='https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=108770&t=l')"
+    "Image(url=\"https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=108770&t=l\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -110,14 +111,14 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "aspirin = pcp.Compound.from_cid(2244)\n",
-    "Image(url='https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=2244&t=l')"
+    "Image(url=\"https://pubchem.ncbi.nlm.nih.gov/image/imgsrv.fcgi?cid=2244&t=l\")"
    ]
   },
   {
@@ -131,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -140,7 +141,7 @@
        "'0000037180703000000000000000000000000000000000000000304000000000000000810000001A00000000000C04809800300E80000400880220D208000208002020000888000608C80C262284311A823A20A4C01108A98780C0200E00000000000800000000000000100000000000000000'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -158,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -167,7 +168,7 @@
        "'0b1101110001100000000111000000110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011000001000000000000000000000000000000000000000000000000000000000000001000000100000000000000000000000000011010000000000000000000000000000000000000000000001100000001001000000010011000000000000011000000001110100000000000000000000100000000001000100000000010001000001101001000001000000000000000001000001000000000000010000000100000000000000000100010001000000000000000011000001000110010000000110000100110001000101000010000110001000110101000001000111010001000001010010011000000000100010000100010101001100001111000000011000000001000000000111000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -193,16 +194,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def tanimoto(compound1, compound2):\n",
     "    fp1 = int(compound1.fingerprint, 16)\n",
     "    fp2 = int(compound2.fingerprint, 16)\n",
-    "    fp1_count = bin(fp1).count('1')\n",
-    "    fp2_count = bin(fp2).count('1')\n",
-    "    both_count = bin(fp1 & fp2).count('1')\n",
+    "    fp1_count = bin(fp1).count(\"1\")\n",
+    "    fp2_count = bin(fp2).count(\"1\")\n",
+    "    both_count = bin(fp1 & fp2).count(\"1\")\n",
     "    return float(both_count) / (fp1_count + fp2_count - both_count)"
    ]
   },
@@ -215,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -224,7 +225,7 @@
        "1.0"
       ]
      },
-     "execution_count": 9,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -235,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -244,7 +245,7 @@
        "0.6011904761904762"
       ]
      },
-     "execution_count": 10,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -255,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -264,7 +265,7 @@
        "0.6011904761904762"
       ]
      },
-     "execution_count": 11,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -275,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -284,7 +285,7 @@
        "0.9529411764705882"
       ]
      },
-     "execution_count": 12,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -295,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -304,7 +305,7 @@
        "0.8211382113821138"
       ]
      },
-     "execution_count": 13,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -324,7 +325,7 @@
        "0.6123595505617978"
       ]
      },
-     "execution_count": 14,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -342,34 +343,9 @@
     "- [Computing Tanimoto scores, quickly](http://www.dalkescientific.com/writings/diary/archive/2008/06/27/computing_tanimoto_scores.html)\n",
     "- [chemfp](http://chemfp.com)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.9"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 1
 }

--- a/pubchempy.py
+++ b/pubchempy.py
@@ -23,78 +23,75 @@ _CA_FILE = os.getenv("PUBCHEMPY_CA_BUNDLE") or os.getenv("REQUESTS_CA_BUNDLE")
 if not _CA_FILE:
     try:
         import certifi
+
         _CA_FILE = certifi.where()
     except ImportError:
         _CA_FILE = None
 
 
-__author__ = 'Matt Swain'
-__email__ = 'm.swain@me.com'
-__version__ = '1.0.4'
-__license__ = 'MIT'
+__author__ = "Matt Swain"
+__email__ = "m.swain@me.com"
+__version__ = "1.0.4"
+__license__ = "MIT"
 
 __all__ = [
     # Main API functions
-    'get_compounds',
-    'get_substances',
-    'get_assays',
-    'get_properties',
-    'get_synonyms',
-    'get_cids',
-    'get_sids',
-    'get_aids',
-    'get_all_sources',
-    'download',
-    'request',
-    'get',
-    'get_json',
-    'get_sdf',
-
+    "get_compounds",
+    "get_substances",
+    "get_assays",
+    "get_properties",
+    "get_synonyms",
+    "get_cids",
+    "get_sids",
+    "get_aids",
+    "get_all_sources",
+    "download",
+    "request",
+    "get",
+    "get_json",
+    "get_sdf",
     # Core classes
-    'Compound',
-    'Substance',
-    'Assay',
-    'Atom',
-    'Bond',
-
+    "Compound",
+    "Substance",
+    "Assay",
+    "Atom",
+    "Bond",
     # Enum/constant classes
-    'CompoundIdType',
-    'BondType',
-    'CoordinateType',
-    'ProjectCategory',
-
+    "CompoundIdType",
+    "BondType",
+    "CoordinateType",
+    "ProjectCategory",
     # Data conversion functions
-    'compounds_to_frame',
-    'substances_to_frame',
-
+    "compounds_to_frame",
+    "substances_to_frame",
     # Constants
-    'API_BASE',
-    'ELEMENTS',
-    'PROPERTY_MAP',
-
+    "API_BASE",
+    "ELEMENTS",
+    "PROPERTY_MAP",
     # Exceptions
-    'PubChemPyError',
-    'ResponseParseError',
-    'PubChemHTTPError',
-    'BadRequestError',
-    'NotFoundError',
-    'MethodNotAllowedError',
-    'ServerError',
-    'UnimplementedError',
-    'ServerBusyError',
-    'TimeoutError',
-    'PubChemPyDeprecationWarning',
+    "PubChemPyError",
+    "ResponseParseError",
+    "PubChemHTTPError",
+    "BadRequestError",
+    "NotFoundError",
+    "MethodNotAllowedError",
+    "ServerError",
+    "UnimplementedError",
+    "ServerBusyError",
+    "TimeoutError",
+    "PubChemPyDeprecationWarning",
 ]
 
 #: Base URL for the PubChem PUG REST API.
-API_BASE = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug'
+API_BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
 
-log = logging.getLogger('pubchempy')
+log = logging.getLogger("pubchempy")
 log.addHandler(logging.NullHandler())
 
 
 class CompoundIdType(enum.IntEnum):
     """Compound record type."""
+
     #: Original Deposited Compound
     DEPOSITED = 0
     #: Standardized Form of a Deposited Compound
@@ -115,6 +112,7 @@ class CompoundIdType(enum.IntEnum):
 
 class BondType(enum.IntEnum):
     """Bond Type Information."""
+
     #: Single Bond
     SINGLE = 1
     #: Double Bond
@@ -135,6 +133,7 @@ class BondType(enum.IntEnum):
 
 class CoordinateType(enum.IntEnum):
     """Coordinate Set Type Distinctions"""
+
     #: 2D Coordinates
     TWO_D = 1
     #: 3D Coordinates (should also indicate units, below)
@@ -169,6 +168,7 @@ class CoordinateType(enum.IntEnum):
 
 class ProjectCategory(enum.IntEnum):
     """To distinguish projects funded through MLSCN, MLPCN or other."""
+
     #: Assay depositions from MLSCN screen center
     MLSCN = 1
     #: Assay depositions from MLPCN screen center
@@ -196,166 +196,178 @@ class ProjectCategory(enum.IntEnum):
 #: Dictionary mapping atomic numbers to their element symbols.
 ELEMENTS = {
     # Standard chemical elements
-    1: 'H',  # Hydrogen
-    2: 'He',  # Helium
-    3: 'Li',  # Lithium
-    4: 'Be',  # Beryllium
-    5: 'B',  # Boron
-    6: 'C',  # Carbon
-    7: 'N',  # Nitrogen
-    8: 'O',  # Oxygen
-    9: 'F',  # Fluorine
-    10: 'Ne',  # Neon
-    11: 'Na',  # Sodium
-    12: 'Mg',  # Magnesium
-    13: 'Al',  # Aluminium
-    14: 'Si',  # Silicon
-    15: 'P',  # Phosphorus
-    16: 'S',  # Sulfur
-    17: 'Cl',  # Chlorine
-    18: 'Ar',  # Argon
-    19: 'K',  # Potassium
-    20: 'Ca',  # Calcium
-    21: 'Sc',  # Scandium
-    22: 'Ti',  # Titanium
-    23: 'V',  # Vanadium
-    24: 'Cr',  # Chromium
-    25: 'Mn',  # Manganese
-    26: 'Fe',  # Iron
-    27: 'Co',  # Cobalt
-    28: 'Ni',  # Nickel
-    29: 'Cu',  # Copper
-    30: 'Zn',  # Zinc
-    31: 'Ga',  # Gallium
-    32: 'Ge',  # Germanium
-    33: 'As',  # Arsenic
-    34: 'Se',  # Selenium
-    35: 'Br',  # Bromine
-    36: 'Kr',  # Krypton
-    37: 'Rb',  # Rubidium
-    38: 'Sr',  # Strontium
-    39: 'Y',  # Yttrium
-    40: 'Zr',  # Zirconium
-    41: 'Nb',  # Niobium
-    42: 'Mo',  # Molybdenum
-    43: 'Tc',  # Technetium
-    44: 'Ru',  # Ruthenium
-    45: 'Rh',  # Rhodium
-    46: 'Pd',  # Palladium
-    47: 'Ag',  # Silver
-    48: 'Cd',  # Cadmium
-    49: 'In',  # Indium
-    50: 'Sn',  # Tin
-    51: 'Sb',  # Antimony
-    52: 'Te',  # Tellurium
-    53: 'I',  # Iodine
-    54: 'Xe',  # Xenon
-    55: 'Cs',  # Cesium
-    56: 'Ba',  # Barium
-    57: 'La',  # Lanthanum
-    58: 'Ce',  # Cerium
-    59: 'Pr',  # Praseodymium
-    60: 'Nd',  # Neodymium
-    61: 'Pm',  # Promethium
-    62: 'Sm',  # Samarium
-    63: 'Eu',  # Europium
-    64: 'Gd',  # Gadolinium
-    65: 'Tb',  # Terbium
-    66: 'Dy',  # Dysprosium
-    67: 'Ho',  # Holmium
-    68: 'Er',  # Erbium
-    69: 'Tm',  # Thulium
-    70: 'Yb',  # Ytterbium
-    71: 'Lu',  # Lutetium
-    72: 'Hf',  # Hafnium
-    73: 'Ta',  # Tantalum
-    74: 'W',  # Tungsten
-    75: 'Re',  # Rhenium
-    76: 'Os',  # Osmium
-    77: 'Ir',  # Iridium
-    78: 'Pt',  # Platinum
-    79: 'Au',  # Gold
-    80: 'Hg',  # Mercury
-    81: 'Tl',  # Thallium
-    82: 'Pb',  # Lead
-    83: 'Bi',  # Bismuth
-    84: 'Po',  # Polonium
-    85: 'At',  # Astatine
-    86: 'Rn',  # Radon
-    87: 'Fr',  # Francium
-    88: 'Ra',  # Radium
-    89: 'Ac',  # Actinium
-    90: 'Th',  # Thorium
-    91: 'Pa',  # Protactinium
-    92: 'U',  # Uranium
-    93: 'Np',  # Neptunium
-    94: 'Pu',  # Plutonium
-    95: 'Am',  # Americium
-    96: 'Cm',  # Curium
-    97: 'Bk',  # Berkelium
-    98: 'Cf',  # Californium
-    99: 'Es',  # Einsteinium
-    100: 'Fm',  # Fermium
-    101: 'Md',  # Mendelevium
-    102: 'No',  # Nobelium
-    103: 'Lr',  # Lawrencium
-    104: 'Rf',  # Rutherfordium
-    105: 'Db',  # Dubnium
-    106: 'Sg',  # Seaborgium
-    107: 'Bh',  # Bohrium
-    108: 'Hs',  # Hassium
-    109: 'Mt',  # Meitnerium
-    110: 'Ds',  # Darmstadtium
-    111: 'Rg',  # Roentgenium
-    112: 'Cn',  # Copernicium
-    113: 'Nh',  # Nihonium
-    114: 'Fl',  # Flerovium
-    115: 'Mc',  # Moscovium
-    116: 'Lv',  # Livermorium
-    117: 'Ts',  # Tennessine
-    118: 'Og',  # Oganesson
-
+    1: "H",  # Hydrogen
+    2: "He",  # Helium
+    3: "Li",  # Lithium
+    4: "Be",  # Beryllium
+    5: "B",  # Boron
+    6: "C",  # Carbon
+    7: "N",  # Nitrogen
+    8: "O",  # Oxygen
+    9: "F",  # Fluorine
+    10: "Ne",  # Neon
+    11: "Na",  # Sodium
+    12: "Mg",  # Magnesium
+    13: "Al",  # Aluminium
+    14: "Si",  # Silicon
+    15: "P",  # Phosphorus
+    16: "S",  # Sulfur
+    17: "Cl",  # Chlorine
+    18: "Ar",  # Argon
+    19: "K",  # Potassium
+    20: "Ca",  # Calcium
+    21: "Sc",  # Scandium
+    22: "Ti",  # Titanium
+    23: "V",  # Vanadium
+    24: "Cr",  # Chromium
+    25: "Mn",  # Manganese
+    26: "Fe",  # Iron
+    27: "Co",  # Cobalt
+    28: "Ni",  # Nickel
+    29: "Cu",  # Copper
+    30: "Zn",  # Zinc
+    31: "Ga",  # Gallium
+    32: "Ge",  # Germanium
+    33: "As",  # Arsenic
+    34: "Se",  # Selenium
+    35: "Br",  # Bromine
+    36: "Kr",  # Krypton
+    37: "Rb",  # Rubidium
+    38: "Sr",  # Strontium
+    39: "Y",  # Yttrium
+    40: "Zr",  # Zirconium
+    41: "Nb",  # Niobium
+    42: "Mo",  # Molybdenum
+    43: "Tc",  # Technetium
+    44: "Ru",  # Ruthenium
+    45: "Rh",  # Rhodium
+    46: "Pd",  # Palladium
+    47: "Ag",  # Silver
+    48: "Cd",  # Cadmium
+    49: "In",  # Indium
+    50: "Sn",  # Tin
+    51: "Sb",  # Antimony
+    52: "Te",  # Tellurium
+    53: "I",  # Iodine
+    54: "Xe",  # Xenon
+    55: "Cs",  # Cesium
+    56: "Ba",  # Barium
+    57: "La",  # Lanthanum
+    58: "Ce",  # Cerium
+    59: "Pr",  # Praseodymium
+    60: "Nd",  # Neodymium
+    61: "Pm",  # Promethium
+    62: "Sm",  # Samarium
+    63: "Eu",  # Europium
+    64: "Gd",  # Gadolinium
+    65: "Tb",  # Terbium
+    66: "Dy",  # Dysprosium
+    67: "Ho",  # Holmium
+    68: "Er",  # Erbium
+    69: "Tm",  # Thulium
+    70: "Yb",  # Ytterbium
+    71: "Lu",  # Lutetium
+    72: "Hf",  # Hafnium
+    73: "Ta",  # Tantalum
+    74: "W",  # Tungsten
+    75: "Re",  # Rhenium
+    76: "Os",  # Osmium
+    77: "Ir",  # Iridium
+    78: "Pt",  # Platinum
+    79: "Au",  # Gold
+    80: "Hg",  # Mercury
+    81: "Tl",  # Thallium
+    82: "Pb",  # Lead
+    83: "Bi",  # Bismuth
+    84: "Po",  # Polonium
+    85: "At",  # Astatine
+    86: "Rn",  # Radon
+    87: "Fr",  # Francium
+    88: "Ra",  # Radium
+    89: "Ac",  # Actinium
+    90: "Th",  # Thorium
+    91: "Pa",  # Protactinium
+    92: "U",  # Uranium
+    93: "Np",  # Neptunium
+    94: "Pu",  # Plutonium
+    95: "Am",  # Americium
+    96: "Cm",  # Curium
+    97: "Bk",  # Berkelium
+    98: "Cf",  # Californium
+    99: "Es",  # Einsteinium
+    100: "Fm",  # Fermium
+    101: "Md",  # Mendelevium
+    102: "No",  # Nobelium
+    103: "Lr",  # Lawrencium
+    104: "Rf",  # Rutherfordium
+    105: "Db",  # Dubnium
+    106: "Sg",  # Seaborgium
+    107: "Bh",  # Bohrium
+    108: "Hs",  # Hassium
+    109: "Mt",  # Meitnerium
+    110: "Ds",  # Darmstadtium
+    111: "Rg",  # Roentgenium
+    112: "Cn",  # Copernicium
+    113: "Nh",  # Nihonium
+    114: "Fl",  # Flerovium
+    115: "Mc",  # Moscovium
+    116: "Lv",  # Livermorium
+    117: "Ts",  # Tennessine
+    118: "Og",  # Oganesson
     # Special atom types
-    252: 'Lp',  # Lone Pair
-    253: 'R',  # Rgroup Label
-    254: '*',  # Dummy Atom
-    255: '*',  # Unspecified Atom (Asterisk)
+    252: "Lp",  # Lone Pair
+    253: "R",  # Rgroup Label
+    254: "*",  # Dummy Atom
+    255: "*",  # Unspecified Atom (Asterisk)
 }
 
 
-def request(identifier, namespace='cid', domain='compound', operation=None, output='JSON', searchtype=None, **kwargs):
+def request(
+    identifier,
+    namespace="cid",
+    domain="compound",
+    operation=None,
+    output="JSON",
+    searchtype=None,
+    **kwargs,
+):
     """
     Construct API request from parameters and return the response.
 
     Full specification at https://pubchem.ncbi.nlm.nih.gov/docs/pug-rest
     """
     if not identifier:
-        raise ValueError('identifier/cid cannot be None')
+        raise ValueError("identifier/cid cannot be None")
     # If identifier is a list, join with commas into string
     if isinstance(identifier, int):
         identifier = str(identifier)
     if not isinstance(identifier, str):
-        identifier = ','.join(str(x) for x in identifier)
+        identifier = ",".join(str(x) for x in identifier)
     # Filter None values from kwargs
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
     # Build API URL
     urlid, postdata = None, None
-    if namespace == 'sourceid':
-        identifier = identifier.replace('/', '.')
-    if namespace in ['listkey', 'formula', 'sourceid'] \
-            or searchtype == 'xref' \
-            or (searchtype and namespace == 'cid') or domain == 'sources':
-        urlid = quote(identifier.encode('utf8'))
+    if namespace == "sourceid":
+        identifier = identifier.replace("/", ".")
+    if (
+        namespace in ["listkey", "formula", "sourceid"]
+        or searchtype == "xref"
+        or (searchtype and namespace == "cid")
+        or domain == "sources"
+    ):
+        urlid = quote(identifier.encode("utf8"))
     else:
-        postdata = urlencode([(namespace, identifier)]).encode('utf8')
-    comps = filter(None, [API_BASE, domain, searchtype, namespace, urlid, operation, output])
-    apiurl = '/'.join(comps)
+        postdata = urlencode([(namespace, identifier)]).encode("utf8")
+    comps = filter(
+        None, [API_BASE, domain, searchtype, namespace, urlid, operation, output]
+    )
+    apiurl = "/".join(comps)
     if kwargs:
-        apiurl += f'?{urlencode(kwargs)}'
+        apiurl += f"?{urlencode(kwargs)}"
     # Make request
     try:
-        log.debug(f'Request URL: {apiurl}')
-        log.debug(f'Request data: {postdata}')
+        log.debug(f"Request URL: {apiurl}")
+        log.debug(f"Request data: {postdata}")
         context = ssl.create_default_context(cafile=_CA_FILE)
         response = urlopen(apiurl, postdata, context=context)
         return response
@@ -363,42 +375,88 @@ def request(identifier, namespace='cid', domain='compound', operation=None, outp
         raise create_http_error(e) from e
 
 
-def get(identifier, namespace='cid', domain='compound', operation=None, output='JSON', searchtype=None, **kwargs):
+def get(
+    identifier,
+    namespace="cid",
+    domain="compound",
+    operation=None,
+    output="JSON",
+    searchtype=None,
+    **kwargs,
+):
     """Request wrapper that automatically handles async requests."""
-    if (searchtype and searchtype != 'xref') or namespace in ['formula']:
-        response = request(identifier, namespace, domain, None, 'JSON', searchtype, **kwargs).read()
+    if (searchtype and searchtype != "xref") or namespace in ["formula"]:
+        response = request(
+            identifier, namespace, domain, None, "JSON", searchtype, **kwargs
+        ).read()
         status = json.loads(response.decode())
-        if 'Waiting' in status and 'ListKey' in status['Waiting']:
-            identifier = status['Waiting']['ListKey']
-            namespace = 'listkey'
-            while 'Waiting' in status and 'ListKey' in status['Waiting']:
+        if "Waiting" in status and "ListKey" in status["Waiting"]:
+            identifier = status["Waiting"]["ListKey"]
+            namespace = "listkey"
+            while "Waiting" in status and "ListKey" in status["Waiting"]:
                 time.sleep(2)
-                response = request(identifier, namespace, domain, operation, 'JSON', **kwargs).read()
+                response = request(
+                    identifier, namespace, domain, operation, "JSON", **kwargs
+                ).read()
                 status = json.loads(response.decode())
-            if not output == 'JSON':
-                response = request(identifier, namespace, domain, operation, output, searchtype, **kwargs).read()
+            if not output == "JSON":
+                response = request(
+                    identifier,
+                    namespace,
+                    domain,
+                    operation,
+                    output,
+                    searchtype,
+                    **kwargs,
+                ).read()
     else:
-        response = request(identifier, namespace, domain, operation, output, searchtype, **kwargs).read()
+        response = request(
+            identifier, namespace, domain, operation, output, searchtype, **kwargs
+        ).read()
     return response
 
 
-def get_json(identifier, namespace='cid', domain='compound', operation=None, searchtype=None, **kwargs):
+def get_json(
+    identifier,
+    namespace="cid",
+    domain="compound",
+    operation=None,
+    searchtype=None,
+    **kwargs,
+):
     """Request wrapper that automatically parses JSON response and supresses NotFoundError."""
     try:
-        return json.loads(get(identifier, namespace, domain, operation, 'JSON', searchtype, **kwargs).decode())
+        return json.loads(
+            get(
+                identifier, namespace, domain, operation, "JSON", searchtype, **kwargs
+            ).decode()
+        )
     except NotFoundError as e:
         log.info(e)
         return None
 
-def get_sdf(identifier, namespace='cid', domain='compound',operation=None, searchtype=None, **kwargs):
+
+def get_sdf(
+    identifier,
+    namespace="cid",
+    domain="compound",
+    operation=None,
+    searchtype=None,
+    **kwargs,
+):
     """Request wrapper that automatically parses SDF response and supresses NotFoundError."""
     try:
-        return get(identifier, namespace, domain, operation, 'SDF', searchtype, **kwargs).decode()
+        return get(
+            identifier, namespace, domain, operation, "SDF", searchtype, **kwargs
+        ).decode()
     except NotFoundError as e:
         log.info(e)
         return None
 
-def get_compounds(identifier, namespace='cid', searchtype=None, as_dataframe=False, **kwargs):
+
+def get_compounds(
+    identifier, namespace="cid", searchtype=None, as_dataframe=False, **kwargs
+):
     """Retrieve the specified compound records from PubChem.
 
     :param identifier: The compound identifier to use as a search query.
@@ -408,13 +466,13 @@ def get_compounds(identifier, namespace='cid', searchtype=None, as_dataframe=Fal
                          :class:`~pandas.DataFrame` and return that.
     """
     results = get_json(identifier, namespace, searchtype=searchtype, **kwargs)
-    compounds = [Compound(r) for r in results['PC_Compounds']] if results else []
+    compounds = [Compound(r) for r in results["PC_Compounds"]] if results else []
     if as_dataframe:
         return compounds_to_frame(compounds)
     return compounds
 
 
-def get_substances(identifier, namespace='sid', as_dataframe=False, **kwargs):
+def get_substances(identifier, namespace="sid", as_dataframe=False, **kwargs):
     """Retrieve the specified substance records from PubChem.
 
     :param identifier: The substance identifier to use as a search query.
@@ -422,71 +480,78 @@ def get_substances(identifier, namespace='sid', as_dataframe=False, **kwargs):
     :param as_dataframe: (optional) Automatically extract the :class:`~pubchempy.Substance` properties into a pandas
                          :class:`~pandas.DataFrame` and return that.
     """
-    results = get_json(identifier, namespace, 'substance', **kwargs)
-    substances = [Substance(r) for r in results['PC_Substances']] if results else []
+    results = get_json(identifier, namespace, "substance", **kwargs)
+    substances = [Substance(r) for r in results["PC_Substances"]] if results else []
     if as_dataframe:
         return substances_to_frame(substances)
     return substances
 
 
-def get_assays(identifier, namespace='aid', **kwargs):
+def get_assays(identifier, namespace="aid", **kwargs):
     """Retrieve the specified assay records from PubChem.
 
     :param identifier: The assay identifier to use as a search query.
     :param namespace: (optional) The identifier type.
     """
-    results = get_json(identifier, namespace, 'assay', 'description', **kwargs)
-    return [Assay(r) for r in results['PC_AssayContainer']] if results else []
+    results = get_json(identifier, namespace, "assay", "description", **kwargs)
+    return [Assay(r) for r in results["PC_AssayContainer"]] if results else []
 
 
 #: Allows properties to optionally be specified as underscore_separated, consistent with Compound attributes.
 PROPERTY_MAP = {
-    'molecular_formula': 'MolecularFormula',
-    'molecular_weight': 'MolecularWeight',
-    'smiles': 'SMILES',
-    'connectivity_smiles': 'ConnectivitySMILES',
-    'canonical_smiles': 'CanonicalSMILES',
-    'isomeric_smiles': 'IsomericSMILES',
-    'inchi': 'InChI',
-    'inchikey': 'InChIKey',
-    'iupac_name': 'IUPACName',
-    'xlogp': 'XLogP',
-    'exact_mass': 'ExactMass',
-    'monoisotopic_mass': 'MonoisotopicMass',
-    'tpsa': 'TPSA',
-    'complexity': 'Complexity',
-    'charge': 'Charge',
-    'h_bond_donor_count': 'HBondDonorCount',
-    'h_bond_acceptor_count': 'HBondAcceptorCount',
-    'rotatable_bond_count': 'RotatableBondCount',
-    'heavy_atom_count': 'HeavyAtomCount',
-    'isotope_atom_count': 'IsotopeAtomCount',
-    'atom_stereo_count': 'AtomStereoCount',
-    'defined_atom_stereo_count': 'DefinedAtomStereoCount',
-    'undefined_atom_stereo_count': 'UndefinedAtomStereoCount',
-    'bond_stereo_count': 'BondStereoCount',
-    'defined_bond_stereo_count': 'DefinedBondStereoCount',
-    'undefined_bond_stereo_count': 'UndefinedBondStereoCount',
-    'covalent_unit_count': 'CovalentUnitCount',
-    'volume_3d': 'Volume3D',
-    'conformer_rmsd_3d': 'ConformerModelRMSD3D',
-    'conformer_model_rmsd_3d': 'ConformerModelRMSD3D',
-    'x_steric_quadrupole_3d': 'XStericQuadrupole3D',
-    'y_steric_quadrupole_3d': 'YStericQuadrupole3D',
-    'z_steric_quadrupole_3d': 'ZStericQuadrupole3D',
-    'feature_count_3d': 'FeatureCount3D',
-    'feature_acceptor_count_3d': 'FeatureAcceptorCount3D',
-    'feature_donor_count_3d': 'FeatureDonorCount3D',
-    'feature_anion_count_3d': 'FeatureAnionCount3D',
-    'feature_cation_count_3d': 'FeatureCationCount3D',
-    'feature_ring_count_3d': 'FeatureRingCount3D',
-    'feature_hydrophobe_count_3d': 'FeatureHydrophobeCount3D',
-    'effective_rotor_count_3d': 'EffectiveRotorCount3D',
-    'conformer_count_3d': 'ConformerCount3D',
+    "molecular_formula": "MolecularFormula",
+    "molecular_weight": "MolecularWeight",
+    "smiles": "SMILES",
+    "connectivity_smiles": "ConnectivitySMILES",
+    "canonical_smiles": "CanonicalSMILES",
+    "isomeric_smiles": "IsomericSMILES",
+    "inchi": "InChI",
+    "inchikey": "InChIKey",
+    "iupac_name": "IUPACName",
+    "xlogp": "XLogP",
+    "exact_mass": "ExactMass",
+    "monoisotopic_mass": "MonoisotopicMass",
+    "tpsa": "TPSA",
+    "complexity": "Complexity",
+    "charge": "Charge",
+    "h_bond_donor_count": "HBondDonorCount",
+    "h_bond_acceptor_count": "HBondAcceptorCount",
+    "rotatable_bond_count": "RotatableBondCount",
+    "heavy_atom_count": "HeavyAtomCount",
+    "isotope_atom_count": "IsotopeAtomCount",
+    "atom_stereo_count": "AtomStereoCount",
+    "defined_atom_stereo_count": "DefinedAtomStereoCount",
+    "undefined_atom_stereo_count": "UndefinedAtomStereoCount",
+    "bond_stereo_count": "BondStereoCount",
+    "defined_bond_stereo_count": "DefinedBondStereoCount",
+    "undefined_bond_stereo_count": "UndefinedBondStereoCount",
+    "covalent_unit_count": "CovalentUnitCount",
+    "volume_3d": "Volume3D",
+    "conformer_rmsd_3d": "ConformerModelRMSD3D",
+    "conformer_model_rmsd_3d": "ConformerModelRMSD3D",
+    "x_steric_quadrupole_3d": "XStericQuadrupole3D",
+    "y_steric_quadrupole_3d": "YStericQuadrupole3D",
+    "z_steric_quadrupole_3d": "ZStericQuadrupole3D",
+    "feature_count_3d": "FeatureCount3D",
+    "feature_acceptor_count_3d": "FeatureAcceptorCount3D",
+    "feature_donor_count_3d": "FeatureDonorCount3D",
+    "feature_anion_count_3d": "FeatureAnionCount3D",
+    "feature_cation_count_3d": "FeatureCationCount3D",
+    "feature_ring_count_3d": "FeatureRingCount3D",
+    "feature_hydrophobe_count_3d": "FeatureHydrophobeCount3D",
+    "effective_rotor_count_3d": "EffectiveRotorCount3D",
+    "conformer_count_3d": "ConformerCount3D",
 }
 
 
-def get_properties(properties, identifier, namespace='cid', searchtype=None, as_dataframe=False, **kwargs):
+def get_properties(
+    properties,
+    identifier,
+    namespace="cid",
+    searchtype=None,
+    as_dataframe=False,
+    **kwargs,
+):
     """Retrieve the specified properties from PubChem.
 
     :param identifier: The compound, substance or assay identifier to use as a search query.
@@ -495,65 +560,91 @@ def get_properties(properties, identifier, namespace='cid', searchtype=None, as_
     :param as_dataframe: (optional) Automatically extract the properties into a pandas :class:`~pandas.DataFrame`.
     """
     if isinstance(properties, str):
-        properties = properties.split(',')
-    properties = ','.join([PROPERTY_MAP.get(p, p) for p in properties])
-    properties = f'property/{properties}'
-    results = get_json(identifier, namespace, 'compound', properties, searchtype=searchtype, **kwargs)
-    results = results['PropertyTable']['Properties'] if results else []
+        properties = properties.split(",")
+    properties = ",".join([PROPERTY_MAP.get(p, p) for p in properties])
+    properties = f"property/{properties}"
+    results = get_json(
+        identifier, namespace, "compound", properties, searchtype=searchtype, **kwargs
+    )
+    results = results["PropertyTable"]["Properties"] if results else []
     if as_dataframe:
         import pandas as pd
-        return pd.DataFrame.from_records(results, index='CID')
+
+        return pd.DataFrame.from_records(results, index="CID")
     return results
 
 
-def get_synonyms(identifier, namespace='cid', domain='compound', searchtype=None, **kwargs):
-    results = get_json(identifier, namespace, domain, 'synonyms', searchtype=searchtype, **kwargs)
-    return results['InformationList']['Information'] if results else []
+def get_synonyms(
+    identifier, namespace="cid", domain="compound", searchtype=None, **kwargs
+):
+    results = get_json(
+        identifier, namespace, domain, "synonyms", searchtype=searchtype, **kwargs
+    )
+    return results["InformationList"]["Information"] if results else []
 
 
-def get_cids(identifier, namespace='name', domain='compound', searchtype=None, **kwargs):
-    results = get_json(identifier, namespace, domain, 'cids', searchtype=searchtype, **kwargs)
+def get_cids(
+    identifier, namespace="name", domain="compound", searchtype=None, **kwargs
+):
+    results = get_json(
+        identifier, namespace, domain, "cids", searchtype=searchtype, **kwargs
+    )
     if not results:
         return []
-    elif 'IdentifierList' in results:
-        return results['IdentifierList']['CID']
-    elif 'InformationList' in results:
-        return results['InformationList']['Information']
+    elif "IdentifierList" in results:
+        return results["IdentifierList"]["CID"]
+    elif "InformationList" in results:
+        return results["InformationList"]["Information"]
 
 
-def get_sids(identifier, namespace='cid', domain='compound', searchtype=None, **kwargs):
-    results = get_json(identifier, namespace, domain, 'sids', searchtype=searchtype, **kwargs)
+def get_sids(identifier, namespace="cid", domain="compound", searchtype=None, **kwargs):
+    results = get_json(
+        identifier, namespace, domain, "sids", searchtype=searchtype, **kwargs
+    )
     if not results:
         return []
-    elif 'IdentifierList' in results:
-        return results['IdentifierList']['SID']
-    elif 'InformationList' in results:
-        return results['InformationList']['Information']
+    elif "IdentifierList" in results:
+        return results["IdentifierList"]["SID"]
+    elif "InformationList" in results:
+        return results["InformationList"]["Information"]
 
 
-def get_aids(identifier, namespace='cid', domain='compound', searchtype=None, **kwargs):
-    results = get_json(identifier, namespace, domain, 'aids', searchtype=searchtype, **kwargs)
+def get_aids(identifier, namespace="cid", domain="compound", searchtype=None, **kwargs):
+    results = get_json(
+        identifier, namespace, domain, "aids", searchtype=searchtype, **kwargs
+    )
     if not results:
         return []
-    elif 'IdentifierList' in results:
-        return results['IdentifierList']['AID']
-    elif 'InformationList' in results:
-        return results['InformationList']['Information']
+    elif "IdentifierList" in results:
+        return results["IdentifierList"]["AID"]
+    elif "InformationList" in results:
+        return results["InformationList"]["Information"]
 
 
-def get_all_sources(domain='substance'):
+def get_all_sources(domain="substance"):
     """Return a list of all current depositors of substances or assays."""
-    results = json.loads(get(domain, None, 'sources').decode())
-    return results['InformationList']['SourceName']
+    results = json.loads(get(domain, None, "sources").decode())
+    return results["InformationList"]["SourceName"]
 
 
-def download(outformat, path, identifier, namespace='cid', domain='compound', operation=None, searchtype=None,
-             overwrite=False, **kwargs):
+def download(
+    outformat,
+    path,
+    identifier,
+    namespace="cid",
+    domain="compound",
+    operation=None,
+    searchtype=None,
+    overwrite=False,
+    **kwargs,
+):
     """Format can be  XML, ASNT/B, JSON, SDF, CSV, PNG, TXT."""
-    response = get(identifier, namespace, domain, operation, outformat, searchtype, **kwargs)
+    response = get(
+        identifier, namespace, domain, operation, outformat, searchtype, **kwargs
+    )
     if not overwrite and os.path.isfile(path):
         raise OSError(f"{path} already exists. Use 'overwrite=True' to overwrite it.")
-    with open(path, 'wb') as f:
+    with open(path, "wb") as f:
         f.write(response)
 
 
@@ -563,28 +654,32 @@ def memoized_property(fget):
     Used to cache :class:`~pubchempy.Compound` and :class:`~pubchempy.Substance` properties that require an additional
     request.
     """
-    attr_name = f'_{fget.__name__}'
+    attr_name = f"_{fget.__name__}"
 
     @functools.wraps(fget)
     def fget_memoized(self):
         if not hasattr(self, attr_name):
             setattr(self, attr_name, fget(self))
         return getattr(self, attr_name)
+
     return property(fget_memoized)
 
 
 def deprecated(message):
     """Decorator to mark as deprecated and emit a warning when used."""
+
     def deco(func):
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
             warnings.warn(
-                f'{func.__name__} is deprecated: {message}',
+                f"{func.__name__} is deprecated: {message}",
                 category=PubChemPyDeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             return func(*args, **kwargs)
+
         return wrapped
+
     return deco
 
 
@@ -615,28 +710,35 @@ class Atom:
         """The formal charge on this atom."""
 
     def __repr__(self):
-        return f'Atom({self.aid!r}, {self.element!r})'
+        return f"Atom({self.aid!r}, {self.element!r})"
 
     def __eq__(self, other):
-        return (isinstance(other, type(self)) and self.aid == other.aid and self.element == other.element and
-                self.x == other.x and self.y == other.y and self.z == other.z and self.charge == other.charge)
+        return (
+            isinstance(other, type(self))
+            and self.aid == other.aid
+            and self.element == other.element
+            and self.x == other.x
+            and self.y == other.y
+            and self.z == other.z
+            and self.charge == other.charge
+        )
 
-    @deprecated('Dictionary style access to Atom attributes is deprecated')
+    @deprecated("Dictionary style access to Atom attributes is deprecated")
     def __getitem__(self, prop):
         """Allow dict-style access to attributes to ease transition from when atoms were dicts."""
-        if prop in {'element', 'x', 'y', 'z', 'charge'}:
+        if prop in {"element", "x", "y", "z", "charge"}:
             return getattr(self, prop)
         raise KeyError(prop)
 
-    @deprecated('Dictionary style access to Atom attributes is deprecated')
+    @deprecated("Dictionary style access to Atom attributes is deprecated")
     def __setitem__(self, prop, val):
         """Allow dict-style setting of attributes to ease transition from when atoms were dicts."""
         setattr(self, prop, val)
 
-    @deprecated('Dictionary style access to Atom attributes is deprecated')
+    @deprecated("Dictionary style access to Atom attributes is deprecated")
     def __contains__(self, prop):
         """Allow dict-style checking of attributes to ease transition from when atoms were dicts."""
-        if prop in {'element', 'x', 'y', 'z', 'charge'}:
+        if prop in {"element", "x", "y", "z", "charge"}:
             return getattr(self, prop) is not None
         return False
 
@@ -647,12 +749,12 @@ class Atom:
 
     def to_dict(self):
         """Return a dictionary containing Atom data."""
-        data = {'aid': self.aid, 'number': self.number, 'element': self.element}
-        for coord in {'x', 'y', 'z'}:
+        data = {"aid": self.aid, "number": self.number, "element": self.element}
+        for coord in {"x", "y", "z"}:
             if getattr(self, coord) is not None:
                 data[coord] = getattr(self, coord)
         if self.charge != 0:
-            data['charge'] = self.charge
+            data["charge"] = self.charge
         return data
 
     def set_coordinates(self, x, y, z=None):
@@ -664,7 +766,7 @@ class Atom:
     @property
     def coordinate_type(self):
         """Whether this atom has 2D or 3D coordinates."""
-        return '2d' if self.z is None else '3d'
+        return "2d" if self.z is None else "3d"
 
 
 class Bond:
@@ -687,32 +789,37 @@ class Bond:
         """Bond style annotation."""
 
     def __repr__(self):
-        return f'Bond({self.aid1!r}, {self.aid2!r}, {self.order!r})'
+        return f"Bond({self.aid1!r}, {self.aid2!r}, {self.order!r})"
 
     def __eq__(self, other):
-        return (isinstance(other, type(self)) and self.aid1 == other.aid1 and self.aid2 == other.aid2 and
-                self.order == other.order and self.style == other.style)
+        return (
+            isinstance(other, type(self))
+            and self.aid1 == other.aid1
+            and self.aid2 == other.aid2
+            and self.order == other.order
+            and self.style == other.style
+        )
 
-    @deprecated('Dictionary style access to Bond attributes is deprecated')
+    @deprecated("Dictionary style access to Bond attributes is deprecated")
     def __getitem__(self, prop):
         """Allow dict-style access to attributes to ease transition from when bonds were dicts."""
-        if prop in {'order', 'style'}:
+        if prop in {"order", "style"}:
             return getattr(self, prop)
         raise KeyError(prop)
 
-    @deprecated('Dictionary style access to Bond attributes is deprecated')
+    @deprecated("Dictionary style access to Bond attributes is deprecated")
     def __setitem__(self, prop, val):
         """Allow dict-style setting of attributes to ease transition from when bonds were dicts."""
         setattr(self, prop, val)
 
-    @deprecated('Dictionary style access to Atom attributes is deprecated')
+    @deprecated("Dictionary style access to Atom attributes is deprecated")
     def __contains__(self, prop):
         """Allow dict-style checking of attributes to ease transition from when bonds were dicts."""
-        if prop in {'order', 'style'}:
+        if prop in {"order", "style"}:
             return getattr(self, prop) is not None
         return False
 
-    @deprecated('Dictionary style access to Atom attributes is deprecated')
+    @deprecated("Dictionary style access to Atom attributes is deprecated")
     def __delitem__(self, prop):
         """Delete the property prop from the wrapped object."""
         if not hasattr(self.__wrapped, prop):
@@ -721,9 +828,9 @@ class Bond:
 
     def to_dict(self):
         """Return a dictionary containing Bond data."""
-        data = {'aid1': self.aid1, 'aid2': self.aid2, 'order': self.order}
+        data = {"aid1": self.aid1, "aid2": self.aid2, "order": self.order}
         if self.style is not None:
-            data['style'] = self.style
+            data["style"] = self.style
         return data
 
 
@@ -733,6 +840,7 @@ class Compound:
     The PubChem Compound database is constructed from the Substance database using a standardization and deduplication
     process. Each Compound is uniquely identified by a CID.
     """
+
     def __init__(self, record):
         """Initialize with a record dict from the PubChem PUG REST service.
 
@@ -753,7 +861,7 @@ class Compound:
     @record.setter
     def record(self, record):
         self._record = record
-        log.debug(f'Created {self}')
+        log.debug(f"Created {self}")
         self._setup_atoms()
         self._setup_bonds()
 
@@ -762,45 +870,52 @@ class Compound:
         # Delete existing atoms
         self._atoms = {}
         # Create atoms
-        aids = self.record['atoms']['aid']
-        elements = self.record['atoms']['element']
+        aids = self.record["atoms"]["aid"]
+        elements = self.record["atoms"]["element"]
         if not len(aids) == len(elements):
-            raise ResponseParseError('Error parsing atom elements')
+            raise ResponseParseError("Error parsing atom elements")
         for aid, element in zip(aids, elements):
             self._atoms[aid] = Atom(aid=aid, number=element)
         # Add coordinates
-        if 'coords' in self.record:
-            coord_ids = self.record['coords'][0]['aid']
-            xs = self.record['coords'][0]['conformers'][0]['x']
-            ys = self.record['coords'][0]['conformers'][0]['y']
-            zs = self.record['coords'][0]['conformers'][0].get('z', [])
-            if not len(coord_ids) == len(xs) == len(ys) == len(self._atoms) or (zs and not len(zs) == len(coord_ids)):
-                raise ResponseParseError('Error parsing atom coordinates')
+        if "coords" in self.record:
+            coord_ids = self.record["coords"][0]["aid"]
+            xs = self.record["coords"][0]["conformers"][0]["x"]
+            ys = self.record["coords"][0]["conformers"][0]["y"]
+            zs = self.record["coords"][0]["conformers"][0].get("z", [])
+            if not len(coord_ids) == len(xs) == len(ys) == len(self._atoms) or (
+                zs and not len(zs) == len(coord_ids)
+            ):
+                raise ResponseParseError("Error parsing atom coordinates")
             for aid, x, y, z in zip_longest(coord_ids, xs, ys, zs):
                 self._atoms[aid].set_coordinates(x, y, z)
         # Add charges
-        if 'charge' in self.record['atoms']:
-            for charge in self.record['atoms']['charge']:
-                self._atoms[charge['aid']].charge = charge['value']
+        if "charge" in self.record["atoms"]:
+            for charge in self.record["atoms"]["charge"]:
+                self._atoms[charge["aid"]].charge = charge["value"]
 
     def _setup_bonds(self):
         """Derive Bond objects from the record."""
         self._bonds = {}
-        if 'bonds' not in self.record:
+        if "bonds" not in self.record:
             return
         # Create bonds
-        aid1s = self.record['bonds']['aid1']
-        aid2s = self.record['bonds']['aid2']
-        orders = self.record['bonds']['order']
+        aid1s = self.record["bonds"]["aid1"]
+        aid2s = self.record["bonds"]["aid2"]
+        orders = self.record["bonds"]["order"]
         if not len(aid1s) == len(aid2s) == len(orders):
-            raise ResponseParseError('Error parsing bonds')
+            raise ResponseParseError("Error parsing bonds")
         for aid1, aid2, order in zip(aid1s, aid2s, orders):
-            self._bonds[frozenset((aid1, aid2))] = Bond(aid1=aid1, aid2=aid2, order=order)
+            self._bonds[frozenset((aid1, aid2))] = Bond(
+                aid1=aid1, aid2=aid2, order=order
+            )
         # Add styles
-        if 'coords' in self.record and 'style' in self.record['coords'][0]['conformers'][0]:
-            aid1s = self.record['coords'][0]['conformers'][0]['style']['aid1']
-            aid2s = self.record['coords'][0]['conformers'][0]['style']['aid2']
-            styles = self.record['coords'][0]['conformers'][0]['style']['annotation']
+        if (
+            "coords" in self.record
+            and "style" in self.record["coords"][0]["conformers"][0]
+        ):
+            aid1s = self.record["coords"][0]["conformers"][0]["style"]["aid1"]
+            aid2s = self.record["coords"][0]["conformers"][0]["style"]["aid2"]
+            styles = self.record["coords"][0]["conformers"][0]["style"]["annotation"]
             for aid1, aid2, style in zip(aid1s, aid2s, styles):
                 self._bonds[frozenset((aid1, aid2))].style = style
 
@@ -814,11 +929,11 @@ class Compound:
 
         :param int cid: The PubChem Compound Identifier (CID).
         """
-        record = json.loads(request(cid, **kwargs).read().decode())['PC_Compounds'][0]
+        record = json.loads(request(cid, **kwargs).read().decode())["PC_Compounds"][0]
         return cls(record)
 
     def __repr__(self):
-        return f'Compound({self.cid if self.cid else ""})'
+        return f"Compound({self.cid if self.cid else ''})"
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and self.record == other.record
@@ -833,9 +948,18 @@ class Compound:
         been replaced by ``connectivity_smiles`` and ``smiles`` respectively.
         """
         if not properties:
-            skip = {'aids', 'sids', 'synonyms', 'canonical_smiles', 'isomeric_smiles'}
-            properties = [p for p in dir(Compound) if isinstance(getattr(Compound, p), property) and p not in skip]
-        return {p: [i.to_dict() for i in getattr(self, p)] if p in {'atoms', 'bonds'} else getattr(self, p) for p in properties}
+            skip = {"aids", "sids", "synonyms", "canonical_smiles", "isomeric_smiles"}
+            properties = [
+                p
+                for p in dir(Compound)
+                if isinstance(getattr(Compound, p), property) and p not in skip
+            ]
+        return {
+            p: [i.to_dict() for i in getattr(self, p)]
+            if p in {"atoms", "bonds"}
+            else getattr(self, p)
+            for p in properties
+        }
 
     def to_series(self, properties=None):
         """Return a pandas :class:`~pandas.Series` containing Compound data. Optionally specify a list of the desired
@@ -845,6 +969,7 @@ class Compound:
         because they each require an extra request.
         """
         import pandas as pd
+
         return pd.Series(self.to_dict(properties))
 
     @property
@@ -857,8 +982,10 @@ class Compound:
             automatically generated record may be returned that contains properties that have been calculated on the
             fly. These records will not have a CID property.
         """
-        if 'id' in self.record and 'id' in self.record['id'] and 'cid' in self.record['id']['id']:
-            return self.record['id']['id']['cid']
+        try:
+            return self.record["id"]["id"]["cid"]
+        except KeyError:
+            return None
 
     @property
     def elements(self):
@@ -882,48 +1009,56 @@ class Compound:
         Requires an extra request. Result is cached.
         """
         if self.cid:
-            results = get_json(self.cid, operation='synonyms')
-            return results['InformationList']['Information'][0]['Synonym'] if results else []
+            results = get_json(self.cid, operation="synonyms")
+            return (
+                results["InformationList"]["Information"][0]["Synonym"]
+                if results
+                else []
+            )
 
     @memoized_property
     def sids(self):
         """Requires an extra request. Result is cached."""
         if self.cid:
-            results = get_json(self.cid, operation='sids')
-            return results['InformationList']['Information'][0]['SID'] if results else []
+            results = get_json(self.cid, operation="sids")
+            return (
+                results["InformationList"]["Information"][0]["SID"] if results else []
+            )
 
     @memoized_property
     def aids(self):
         """Requires an extra request. Result is cached."""
         if self.cid:
-            results = get_json(self.cid, operation='aids')
-            return results['InformationList']['Information'][0]['AID'] if results else []
+            results = get_json(self.cid, operation="aids")
+            return (
+                results["InformationList"]["Information"][0]["AID"] if results else []
+            )
 
     @property
     def coordinate_type(self):
-        if CoordinateType.TWO_D in self.record['coords'][0]['type']:
-            return '2d'
-        elif CoordinateType.THREE_D in self.record['coords'][0]['type']:
-            return '3d'
+        if CoordinateType.TWO_D in self.record["coords"][0]["type"]:
+            return "2d"
+        elif CoordinateType.THREE_D in self.record["coords"][0]["type"]:
+            return "3d"
 
     @property
     def charge(self):
         """Formal charge on this Compound."""
-        return self.record['charge'] if 'charge' in self.record else 0
+        return self.record["charge"] if "charge" in self.record else 0
 
     @property
     def molecular_formula(self):
         """Molecular formula."""
-        return _parse_prop({'label': 'Molecular Formula'}, self.record['props'])
+        return _parse_prop({"label": "Molecular Formula"}, self.record["props"])
 
     @property
     def molecular_weight(self):
         """Molecular Weight."""
-        sval = _parse_prop({'label': 'Molecular Weight'}, self.record['props'])
+        sval = _parse_prop({"label": "Molecular Weight"}, self.record["props"])
         return float(sval) if sval else None
 
     @property
-    @deprecated('Use connectivity_smiles instead')
+    @deprecated("Use connectivity_smiles instead")
     def canonical_smiles(self):
         """Canonical SMILES, with no stereochemistry information (deprecated).
 
@@ -934,7 +1069,7 @@ class Compound:
         return self.connectivity_smiles
 
     @property
-    @deprecated('Use smiles instead')
+    @deprecated("Use smiles instead")
     def isomeric_smiles(self):
         """Isomeric SMILES.
 
@@ -951,7 +1086,9 @@ class Compound:
 
         Replaces the the deprecated :attr:`canonical_smiles` property.
         """
-        return _parse_prop({'label': 'SMILES', 'name': 'Connectivity'}, self.record['props'])
+        return _parse_prop(
+            {"label": "SMILES", "name": "Connectivity"}, self.record["props"]
+        )
 
     @property
     def smiles(self):
@@ -961,70 +1098,78 @@ class Compound:
 
         Replaces the deprecated :attr:`isomeric_smiles` property.
         """
-        return _parse_prop({'label': 'SMILES', 'name': 'Absolute'}, self.record['props'])
+        return _parse_prop(
+            {"label": "SMILES", "name": "Absolute"}, self.record["props"]
+        )
 
     @property
     def inchi(self):
         """InChI string."""
-        return _parse_prop({'label': 'InChI', 'name': 'Standard'}, self.record['props'])
+        return _parse_prop({"label": "InChI", "name": "Standard"}, self.record["props"])
 
     @property
     def inchikey(self):
         """InChIKey."""
-        return _parse_prop({'label': 'InChIKey', 'name': 'Standard'}, self.record['props'])
+        return _parse_prop(
+            {"label": "InChIKey", "name": "Standard"}, self.record["props"]
+        )
 
     @property
     def iupac_name(self):
         """Preferred IUPAC name."""
         # Note: Allowed, CAS-like Style, Preferred, Systematic, Traditional are available in full record
-        return _parse_prop({'label': 'IUPAC Name', 'name': 'Preferred'}, self.record['props'])
+        return _parse_prop(
+            {"label": "IUPAC Name", "name": "Preferred"}, self.record["props"]
+        )
 
     @property
     def xlogp(self):
         """XLogP."""
-        return _parse_prop({'label': 'Log P'}, self.record['props'])
+        return _parse_prop({"label": "Log P"}, self.record["props"])
 
     @property
     def exact_mass(self):
         """Exact mass."""
-        sval = _parse_prop({'label': 'Mass', 'name': 'Exact'}, self.record['props'])
+        sval = _parse_prop({"label": "Mass", "name": "Exact"}, self.record["props"])
         return float(sval) if sval else None
 
     @property
     def monoisotopic_mass(self):
         """Monoisotopic mass."""
-        sval = _parse_prop({'label': 'Weight', 'name': 'MonoIsotopic'}, self.record['props'])
+        sval = _parse_prop(
+            {"label": "Weight", "name": "MonoIsotopic"}, self.record["props"]
+        )
         return float(sval) if sval else None
 
     @property
     def tpsa(self):
         """Topological Polar Surface Area."""
-        return _parse_prop({'implementation': 'E_TPSA'}, self.record['props'])
+        return _parse_prop({"implementation": "E_TPSA"}, self.record["props"])
 
     @property
     def complexity(self):
         """Complexity."""
-        return _parse_prop({'implementation': 'E_COMPLEXITY'}, self.record['props'])
+        return _parse_prop({"implementation": "E_COMPLEXITY"}, self.record["props"])
 
     @property
     def h_bond_donor_count(self):
         """Hydrogen bond donor count."""
-        return _parse_prop({'implementation': 'E_NHDONORS'}, self.record['props'])
+        return _parse_prop({"implementation": "E_NHDONORS"}, self.record["props"])
 
     @property
     def h_bond_acceptor_count(self):
         """Hydrogen bond acceptor count."""
-        return _parse_prop({'implementation': 'E_NHACCEPTORS'}, self.record['props'])
+        return _parse_prop({"implementation": "E_NHACCEPTORS"}, self.record["props"])
 
     @property
     def rotatable_bond_count(self):
         """Rotatable bond count."""
-        return _parse_prop({'implementation': 'E_NROTBONDS'}, self.record['props'])
+        return _parse_prop({"implementation": "E_NROTBONDS"}, self.record["props"])
 
     @property
     def fingerprint(self):
         """Raw padded and hex-encoded fingerprint, as returned by the PUG REST API."""
-        return _parse_prop({'implementation': 'E_SCREEN'}, self.record['props'])
+        return _parse_prop({"implementation": "E_SCREEN"}, self.record["props"])
 
     @property
     def cactvs_fingerprint(self):
@@ -1035,128 +1180,140 @@ class Compound:
         More information at ftp://ftp.ncbi.nlm.nih.gov/pubchem/specifications/pubchem_fingerprints.txt
         """
         # Skip first 4 bytes (contain length of fingerprint) and last 7 bits (padding) then re-pad to 881 bits
-        return f'{int(self.fingerprint[8:], 16):020b}'[:-7].zfill(881)
+        return f"{int(self.fingerprint[8:], 16):020b}"[:-7].zfill(881)
 
     @property
     def heavy_atom_count(self):
         """Heavy atom count."""
-        if 'count' in self.record and 'heavy_atom' in self.record['count']:
-            return self.record['count']['heavy_atom']
+        if "count" in self.record and "heavy_atom" in self.record["count"]:
+            return self.record["count"]["heavy_atom"]
 
     @property
     def isotope_atom_count(self):
         """Isotope atom count."""
-        if 'count' in self.record and 'isotope_atom' in self.record['count']:
-            return self.record['count']['isotope_atom']
+        if "count" in self.record and "isotope_atom" in self.record["count"]:
+            return self.record["count"]["isotope_atom"]
 
     @property
     def atom_stereo_count(self):
         """Atom stereocenter count."""
-        if 'count' in self.record and 'atom_chiral' in self.record['count']:
-            return self.record['count']['atom_chiral']
+        if "count" in self.record and "atom_chiral" in self.record["count"]:
+            return self.record["count"]["atom_chiral"]
 
     @property
     def defined_atom_stereo_count(self):
         """Defined atom stereocenter count."""
-        if 'count' in self.record and 'atom_chiral_def' in self.record['count']:
-            return self.record['count']['atom_chiral_def']
+        if "count" in self.record and "atom_chiral_def" in self.record["count"]:
+            return self.record["count"]["atom_chiral_def"]
 
     @property
     def undefined_atom_stereo_count(self):
         """Undefined atom stereocenter count."""
-        if 'count' in self.record and 'atom_chiral_undef' in self.record['count']:
-            return self.record['count']['atom_chiral_undef']
+        if "count" in self.record and "atom_chiral_undef" in self.record["count"]:
+            return self.record["count"]["atom_chiral_undef"]
 
     @property
     def bond_stereo_count(self):
         """Bond stereocenter count."""
-        if 'count' in self.record and 'bond_chiral' in self.record['count']:
-            return self.record['count']['bond_chiral']
+        if "count" in self.record and "bond_chiral" in self.record["count"]:
+            return self.record["count"]["bond_chiral"]
 
     @property
     def defined_bond_stereo_count(self):
         """Defined bond stereocenter count."""
-        if 'count' in self.record and 'bond_chiral_def' in self.record['count']:
-            return self.record['count']['bond_chiral_def']
+        if "count" in self.record and "bond_chiral_def" in self.record["count"]:
+            return self.record["count"]["bond_chiral_def"]
 
     @property
     def undefined_bond_stereo_count(self):
         """Undefined bond stereocenter count."""
-        if 'count' in self.record and 'bond_chiral_undef' in self.record['count']:
-            return self.record['count']['bond_chiral_undef']
+        if "count" in self.record and "bond_chiral_undef" in self.record["count"]:
+            return self.record["count"]["bond_chiral_undef"]
 
     @property
     def covalent_unit_count(self):
         """Covalently-bonded unit count."""
-        if 'count' in self.record and 'covalent_unit' in self.record['count']:
-            return self.record['count']['covalent_unit']
+        if "count" in self.record and "covalent_unit" in self.record["count"]:
+            return self.record["count"]["covalent_unit"]
 
     @property
     def volume_3d(self):
-        conf = self.record['coords'][0]['conformers'][0]
-        if 'data' in conf:
-            return _parse_prop({'label': 'Shape', 'name': 'Volume'}, conf['data'])
+        conf = self.record["coords"][0]["conformers"][0]
+        if "data" in conf:
+            return _parse_prop({"label": "Shape", "name": "Volume"}, conf["data"])
 
     @property
     def multipoles_3d(self):
-        conf = self.record['coords'][0]['conformers'][0]
-        if 'data' in conf:
-            return _parse_prop({'label': 'Shape', 'name': 'Multipoles'}, conf['data'])
+        conf = self.record["coords"][0]["conformers"][0]
+        if "data" in conf:
+            return _parse_prop({"label": "Shape", "name": "Multipoles"}, conf["data"])
 
     @property
     def conformer_rmsd_3d(self):
-        coords = self.record['coords'][0]
-        if 'data' in coords:
-            return _parse_prop({'label': 'Conformer', 'name': 'RMSD'}, coords['data'])
+        coords = self.record["coords"][0]
+        if "data" in coords:
+            return _parse_prop({"label": "Conformer", "name": "RMSD"}, coords["data"])
 
     @property
     def effective_rotor_count_3d(self):
-        return _parse_prop({'label': 'Count', 'name': 'Effective Rotor'}, self.record['props'])
+        return _parse_prop(
+            {"label": "Count", "name": "Effective Rotor"}, self.record["props"]
+        )
 
     @property
     def pharmacophore_features_3d(self):
-        return _parse_prop({'label': 'Features', 'name': 'Pharmacophore'}, self.record['props'])
+        return _parse_prop(
+            {"label": "Features", "name": "Pharmacophore"}, self.record["props"]
+        )
 
     @property
     def mmff94_partial_charges_3d(self):
-        return _parse_prop({'label': 'Charge', 'name': 'MMFF94 Partial'}, self.record['props'])
+        return _parse_prop(
+            {"label": "Charge", "name": "MMFF94 Partial"}, self.record["props"]
+        )
 
     @property
     def mmff94_energy_3d(self):
-        conf = self.record['coords'][0]['conformers'][0]
-        if 'data' in conf:
-            return _parse_prop({'label': 'Energy', 'name': 'MMFF94 NoEstat'}, conf['data'])
+        conf = self.record["coords"][0]["conformers"][0]
+        if "data" in conf:
+            return _parse_prop(
+                {"label": "Energy", "name": "MMFF94 NoEstat"}, conf["data"]
+            )
 
     @property
     def conformer_id_3d(self):
-        conf = self.record['coords'][0]['conformers'][0]
-        if 'data' in conf:
-            return _parse_prop({'label': 'Conformer', 'name': 'ID'}, conf['data'])
+        conf = self.record["coords"][0]["conformers"][0]
+        if "data" in conf:
+            return _parse_prop({"label": "Conformer", "name": "ID"}, conf["data"])
 
     @property
     def shape_selfoverlap_3d(self):
-        conf = self.record['coords'][0]['conformers'][0]
-        if 'data' in conf:
-            return _parse_prop({'label': 'Shape', 'name': 'Self Overlap'}, conf['data'])
+        conf = self.record["coords"][0]["conformers"][0]
+        if "data" in conf:
+            return _parse_prop({"label": "Shape", "name": "Self Overlap"}, conf["data"])
 
     @property
     def feature_selfoverlap_3d(self):
-        conf = self.record['coords'][0]['conformers'][0]
-        if 'data' in conf:
-            return _parse_prop({'label': 'Feature', 'name': 'Self Overlap'}, conf['data'])
+        conf = self.record["coords"][0]["conformers"][0]
+        if "data" in conf:
+            return _parse_prop(
+                {"label": "Feature", "name": "Self Overlap"}, conf["data"]
+            )
 
     @property
     def shape_fingerprint_3d(self):
-        conf = self.record['coords'][0]['conformers'][0]
-        if 'data' in conf:
-            return _parse_prop({'label': 'Fingerprint', 'name': 'Shape'}, conf['data'])
+        conf = self.record["coords"][0]["conformers"][0]
+        if "data" in conf:
+            return _parse_prop({"label": "Fingerprint", "name": "Shape"}, conf["data"])
 
 
 def _parse_prop(search, proplist):
     """Extract property value from record using the given urn search filter."""
-    props = [i for i in proplist if all(item in i['urn'].items() for item in search.items())]
+    props = [
+        i for i in proplist if all(item in i["urn"].items() for item in search.items())
+    ]
     if len(props) > 0:
-        return props[0]['value'][list(props[0]['value'].keys())[0]]
+        return props[0]["value"][list(props[0]["value"].keys())[0]]
 
 
 class Substance:
@@ -1177,7 +1334,9 @@ class Substance:
 
         :param int sid: The PubChem Substance Identifier (SID).
         """
-        record = json.loads(request(sid, 'sid', 'substance').read().decode())['PC_Substances'][0]
+        record = json.loads(request(sid, "sid", "substance").read().decode())[
+            "PC_Substances"
+        ][0]
         return cls(record)
 
     def __init__(self, record):
@@ -1185,7 +1344,7 @@ class Substance:
         """A dictionary containing the full Substance record that all other properties are obtained from."""
 
     def __repr__(self):
-        return f'Substance({self.sid if self.sid else ""})'
+        return f"Substance({self.sid if self.sid else ''})"
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and self.record == other.record
@@ -1199,8 +1358,12 @@ class Substance:
         :param properties: (optional) A list of the desired properties.
         """
         if not properties:
-            skip = {'deposited_compound', 'standardized_compound', 'cids', 'aids'}
-            properties = [p for p in dir(Substance) if isinstance(getattr(Substance, p), property) and p not in skip]
+            skip = {"deposited_compound", "standardized_compound", "cids", "aids"}
+            properties = [
+                p
+                for p in dir(Substance)
+                if isinstance(getattr(Substance, p), property) and p not in skip
+            ]
         return {p: getattr(self, p) for p in properties}
 
     def to_series(self, properties=None):
@@ -1212,28 +1375,29 @@ class Substance:
         :param properties: (optional) A list of the desired properties.
         """
         import pandas as pd
+
         return pd.Series(self.to_dict(properties))
 
     @property
     def sid(self):
         """The PubChem Substance Idenfitier (SID)."""
-        return self.record['sid']['id']
+        return self.record["sid"]["id"]
 
     @property
     def synonyms(self):
         """A ranked list of all the names associated with this Substance."""
-        if 'synonyms' in self.record:
-            return self.record['synonyms']
+        if "synonyms" in self.record:
+            return self.record["synonyms"]
 
     @property
     def source_name(self):
         """The name of the PubChem depositor that was the source of this Substance."""
-        return self.record['source']['db']['name']
+        return self.record["source"]["db"]["name"]
 
     @property
     def source_id(self):
         """Unique ID for this Substance within those from the same PubChem depositor source."""
-        return self.record['source']['db']['source_id']['str']
+        return self.record["source"]["db"]["source_id"]["str"]
 
     @property
     def standardized_cid(self):
@@ -1241,9 +1405,9 @@ class Substance:
 
         May not exist if this Substance was not standardizable.
         """
-        for c in self.record.get('compound', []):
-            if c['id']['type'] == CompoundIdType.STANDARDIZED:
-                return c['id']['id']['cid']
+        for c in self.record.get("compound", []):
+            if c["id"]["type"] == CompoundIdType.STANDARDIZED:
+                return c["id"]["id"]["cid"]
 
     @memoized_property
     def standardized_compound(self):
@@ -1261,8 +1425,8 @@ class Substance:
 
         The resulting :class:`~pubchempy.Compound` will not have a ``cid`` and will be missing most properties.
         """
-        for c in self.record.get('compound', []):
-            if c['id']['type'] == CompoundIdType.DEPOSITED:
+        for c in self.record.get("compound", []):
+            if c["id"]["type"] == CompoundIdType.DEPOSITED:
                 return Compound(c)
 
     @memoized_property
@@ -1270,27 +1434,28 @@ class Substance:
         """A list of all CIDs for Compounds that were produced when this Substance was standardized.
 
         Requires an extra request. Result is cached."""
-        results = get_json(self.sid, 'sid', 'substance', 'cids')
-        return results['InformationList']['Information'][0]['CID'] if results else []
+        results = get_json(self.sid, "sid", "substance", "cids")
+        return results["InformationList"]["Information"][0]["CID"] if results else []
 
     @memoized_property
     def aids(self):
         """A list of all AIDs for Assays associated with this Substance.
 
         Requires an extra request. Result is cached."""
-        results = get_json(self.sid, 'sid', 'substance', 'aids')
-        return results['InformationList']['Information'][0]['AID'] if results else []
+        results = get_json(self.sid, "sid", "substance", "aids")
+        return results["InformationList"]["Information"][0]["AID"] if results else []
 
 
 class Assay:
-
     @classmethod
     def from_aid(cls, aid):
         """Retrieve the Assay record for the specified AID.
 
         :param int aid: The PubChem Assay Identifier (AID).
         """
-        record = json.loads(request(aid, 'aid', 'assay', 'description').read().decode())['PC_AssayContainer'][0]
+        record = json.loads(
+            request(aid, "aid", "assay", "description").read().decode()
+        )["PC_AssayContainer"][0]
         return cls(record)
 
     def __init__(self, record):
@@ -1298,7 +1463,7 @@ class Assay:
         """A dictionary containing the full Assay record that all other properties are obtained from."""
 
     def __repr__(self):
-        return f'Assay({self.aid if self.aid else ""})'
+        return f"Assay({self.aid if self.aid else ''})"
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and self.record == other.record
@@ -1311,23 +1476,25 @@ class Assay:
         :param properties: (optional) A list of the desired properties.
         """
         if not properties:
-            properties = [p for p in dir(Assay) if isinstance(getattr(Assay, p), property)]
+            properties = [
+                p for p in dir(Assay) if isinstance(getattr(Assay, p), property)
+            ]
         return {p: getattr(self, p) for p in properties}
 
     @property
     def aid(self):
-        """The PubChem Substance Idenfitier (SID)."""
-        return self.record['assay']['descr']['aid']['id']
+        """The PubChem Assay Idenfitier (AID)."""
+        return self.record["assay"]["descr"]["aid"]["id"]
 
     @property
     def name(self):
         """The short assay name, used for display purposes."""
-        return self.record['assay']['descr']['name']
+        return self.record["assay"]["descr"]["name"]
 
     @property
     def description(self):
         """Description."""
-        return self.record['assay']['descr']['description']
+        return self.record["assay"]["descr"]["description"]
 
     @property
     def project_category(self):
@@ -1336,34 +1503,36 @@ class Assay:
         Possible values include mlscn, mlpcn, mlscn-ap, mlpcn-ap, literature-extracted, literature-author,
         literature-publisher, rnaigi.
         """
-        if 'project_category' in self.record['assay']['descr']:
-            return ProjectCategory(self.record['assay']['descr']['project_category'])
+        if "project_category" in self.record["assay"]["descr"]:
+            return ProjectCategory(self.record["assay"]["descr"]["project_category"])
 
     @property
     def comments(self):
         """Comments and additional information."""
-        return [comment for comment in self.record['assay']['descr']['comment'] if comment]
+        return [
+            comment for comment in self.record["assay"]["descr"]["comment"] if comment
+        ]
 
     @property
     def results(self):
         """A list of dictionaries containing details of the results from this Assay."""
-        return self.record['assay']['descr']['results']
+        return self.record["assay"]["descr"]["results"]
 
     @property
     def target(self):
         """A list of dictionaries containing details of the Assay targets."""
-        if 'target' in self.record['assay']['descr']:
-            return self.record['assay']['descr']['target']
+        if "target" in self.record["assay"]["descr"]:
+            return self.record["assay"]["descr"]["target"]
 
     @property
     def revision(self):
         """Revision identifier for textual description."""
-        return self.record['assay']['descr']['revision']
+        return self.record["assay"]["descr"]["revision"]
 
     @property
     def aid_version(self):
         """Incremented when the original depositor updates the record."""
-        return self.record['assay']['descr']['aid']['version']
+        return self.record["assay"]["descr"]["aid"]["version"]
 
 
 def compounds_to_frame(compounds, properties=None):
@@ -1372,10 +1541,13 @@ def compounds_to_frame(compounds, properties=None):
     Optionally specify a list of the desired :class:`~pubchempy.Compound` properties.
     """
     import pandas as pd
+
     if isinstance(compounds, Compound):
         compounds = [compounds]
-    properties = set(properties) | {'cid'} if properties else None
-    return pd.DataFrame.from_records([c.to_dict(properties) for c in compounds], index='cid')
+    properties = set(properties) | {"cid"} if properties else None
+    return pd.DataFrame.from_records(
+        [c.to_dict(properties) for c in compounds], index="cid"
+    )
 
 
 def substances_to_frame(substances, properties=None):
@@ -1384,35 +1556,30 @@ def substances_to_frame(substances, properties=None):
     Optionally specify a list of the desired :class:`~pubchempy.Substance` properties.
     """
     import pandas as pd
+
     if isinstance(substances, Substance):
         substances = [substances]
-    properties = set(properties) | {'sid'} if properties else None
-    return pd.DataFrame.from_records([s.to_dict(properties) for s in substances], index='sid')
-
-
-# def add_columns_to_frame(dataframe, id_col, id_namespace, add_cols):
-#     """"""
-#     # Existing dataframe with some identifier column
-#     # But consider what to do if the identifier column is an index?
-#     # What about having the Compound/Substance object as a column?
+    properties = set(properties) | {"sid"} if properties else None
+    return pd.DataFrame.from_records(
+        [s.to_dict(properties) for s in substances], index="sid"
+    )
 
 
 class PubChemPyDeprecationWarning(Warning):
     """Warning category for deprecated features."""
-    pass
 
 
 class PubChemPyError(Exception):
     """Base class for all PubChemPy exceptions."""
-    pass
 
 
 class ResponseParseError(PubChemPyError):
     """PubChem response is uninterpretable."""
-    pass
+
 
 class PubChemHTTPError(PubChemPyError):
     """Generic error class to handle HTTP error codes."""
+
     def __init__(self, code: int, msg: str, details: list[str]) -> None:
         super().__init__(msg)
         self.code = code
@@ -1420,14 +1587,16 @@ class PubChemHTTPError(PubChemPyError):
         self.details = details
 
     def __str__(self) -> str:
-        output = f'PubChem HTTP Error {self.code} {self.msg}'
+        output = f"PubChem HTTP Error {self.code} {self.msg}"
         if self.details:
-            details = ', '.join(self.details)
-            output = f'{output} ({details})'
+            details = ", ".join(self.details)
+            output = f"{output} ({details})"
         return output
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}({self.code!r}, {self.msg!r}, {self.details!r})'
+        return (
+            f"{self.__class__.__name__}({self.code!r}, {self.msg!r}, {self.details!r})"
+        )
 
 
 def create_http_error(e: HTTPError) -> PubChemHTTPError:
@@ -1436,11 +1605,11 @@ def create_http_error(e: HTTPError) -> PubChemHTTPError:
     msg = e.msg
     details = []
     try:
-        fault = json.loads(e.read().decode())['Fault']
-        msg = fault.get('Code', msg)
-        if 'Message' in fault:
-            msg = f'{msg}: {fault["Message"]}'
-        details = fault.get('Details', [])
+        fault = json.loads(e.read().decode())["Fault"]
+        msg = fault.get("Code", msg)
+        if "Message" in fault:
+            msg = f"{msg}: {fault['Message']}"
+        details = fault.get("Details", [])
     except (ValueError, IndexError, KeyError):
         pass
 
@@ -1468,6 +1637,7 @@ class NotFoundError(PubChemHTTPError):
 class MethodNotAllowedError(PubChemHTTPError):
     """405: Request not allowed (such as invalid MIME type in the HTTP Accept header)."""
 
+
 class ServerError(PubChemHTTPError):
     """500: Some problem on the server side (such as a database server down, etc.)."""
 
@@ -1487,5 +1657,5 @@ class TimeoutError(PubChemHTTPError):
     """
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(__version__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest configuration for PubChemPy tests."""
 
 import time
+
 import pytest
 
 

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -1,17 +1,11 @@
-"""
-test_assay
-~~~~~~~~~~
-
-Test assay object.
-
-"""
+"""Test assay object."""
 
 import pytest
 
 from pubchempy import Assay, ProjectCategory
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def a1():
     """Assay AID 1973374."""
     return Assay.from_aid(1973374)
@@ -19,7 +13,7 @@ def a1():
 
 def test_basic(a1):
     assert a1.aid == 1973374
-    assert repr(a1) == 'Assay(1973374)'
+    assert repr(a1) == "Assay(1973374)"
     assert a1.record
 
 

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -1,10 +1,4 @@
-"""
-test_compound
-~~~~~~~~~~~~~
-
-Test compound object.
-
-"""
+"""Test compound object."""
 
 import re
 import warnings
@@ -20,13 +14,13 @@ from pubchempy import (
 )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def c1():
     """Compound CID 241."""
     return Compound.from_cid(241)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def c2():
     """Compound CID 175."""
     return Compound.from_cid(175)
@@ -35,22 +29,25 @@ def c2():
 def test_basic(c1):
     """Test Compound is retrieved and has a record and correct CID."""
     assert c1.cid == 241
-    assert repr(c1) == 'Compound(241)'
+    assert repr(c1) == "Compound(241)"
     assert c1.record
 
 
 def test_atoms(c1):
     assert len(c1.atoms) == 12
-    assert {a.element for a in c1.atoms} == {'C', 'H'}
-    assert set(c1.elements) == {'C', 'H'}
+    assert {a.element for a in c1.atoms} == {"C", "H"}
+    assert set(c1.elements) == {"C", "H"}
 
 
 def test_atoms_deprecated(c1):
     with warnings.catch_warnings(record=True) as w:
-        assert {a['element'] for a in c1.atoms} == {'C', 'H'}
+        assert {a["element"] for a in c1.atoms} == {"C", "H"}
         assert len(w) == 1
         assert w[0].category == PubChemPyDeprecationWarning
-        assert str(w[0].message) == '__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated'
+        assert (
+            str(w[0].message)
+            == "__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated"
+        )
 
 
 def test_single_atom():
@@ -67,10 +64,13 @@ def test_bonds(c1):
 
 def test_bonds_deprecated(c1):
     with warnings.catch_warnings(record=True) as w:
-        assert {b['order'] for b in c1.bonds} == {BondType.SINGLE, BondType.DOUBLE}
+        assert {b["order"] for b in c1.bonds} == {BondType.SINGLE, BondType.DOUBLE}
         assert len(w) == 1
         assert w[0].category == PubChemPyDeprecationWarning
-        assert str(w[0].message) == '__getitem__ is deprecated: Dictionary style access to Bond attributes is deprecated'
+        assert (
+            str(w[0].message)
+            == "__getitem__ is deprecated: Dictionary style access to Bond attributes is deprecated"
+        )
 
 
 def test_charge(c1):
@@ -86,19 +86,22 @@ def test_coordinates(c1):
 
 def test_coordinates_deprecated(c1):
     with warnings.catch_warnings(record=True) as w:
-        assert isinstance(c1.atoms[0]['x'], (float, int))
-        assert isinstance(c1.atoms[0]['y'], (float, int))
-        assert 'z' not in c1.atoms[0]
+        assert isinstance(c1.atoms[0]["x"], (float, int))
+        assert isinstance(c1.atoms[0]["y"], (float, int))
+        assert "z" not in c1.atoms[0]
         assert len(w) == 3
         assert w[0].category == PubChemPyDeprecationWarning
-        assert str(w[0].message) == '__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated'
+        assert (
+            str(w[0].message)
+            == "__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated"
+        )
 
 
 def test_identifiers(c1):
     assert len(c1.connectivity_smiles) > 10
     assert len(c1.smiles) > 10
-    assert c1.inchi.startswith('InChI=')
-    assert re.match(r'^[A-Z]{14}-[A-Z]{10}-[A-Z\d]$', c1.inchikey)
+    assert c1.inchi.startswith("InChI=")
+    assert re.match(r"^[A-Z]{14}-[A-Z]{10}-[A-Z\d]$", c1.inchikey)
     # TODO: c1.molecular_formula
 
 
@@ -126,12 +129,12 @@ def test_properties_types(c1):
 
 
 def test_coordinate_type(c1):
-    assert c1.coordinate_type == '2d'
+    assert c1.coordinate_type == "2d"
 
 
 def test_compound_equality():
     assert Compound.from_cid(241) == Compound.from_cid(241)
-    assert get_compounds('Benzene', 'name')[0], get_compounds('c1ccccc1' == 'smiles')[0]
+    assert get_compounds("Benzene", "name")[0], get_compounds("c1ccccc1" == "smiles")[0]
 
 
 def test_synonyms(c1):
@@ -147,9 +150,9 @@ def test_related_records(c1):
 def test_compound_dict(c1):
     assert isinstance(c1.to_dict(), dict)
     assert c1.to_dict()
-    assert 'atoms' in c1.to_dict()
-    assert 'bonds' in c1.to_dict()
-    assert 'element' in c1.to_dict()['atoms'][0]
+    assert "atoms" in c1.to_dict()
+    assert "bonds" in c1.to_dict()
+    assert "element" in c1.to_dict()["atoms"][0]
 
 
 def test_charged_compound(c2):
@@ -159,10 +162,13 @@ def test_charged_compound(c2):
 
 def test_charged_compound_deprecated(c2):
     with warnings.catch_warnings(record=True) as w:
-        assert c2.atoms[0]['charge'] == -1
+        assert c2.atoms[0]["charge"] == -1
         assert len(w) == 1
         assert w[0].category == PubChemPyDeprecationWarning
-        assert str(w[0].message) == '__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated'
+        assert (
+            str(w[0].message)
+            == "__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated"
+        )
 
 
 def test_fingerprint(c1):

--- a/tests/test_compound3d.py
+++ b/tests/test_compound3d.py
@@ -1,10 +1,4 @@
-"""
-test_compound3d
-~~~~~~~~~~~~~~~
-
-Test compound object with 3D record.
-
-"""
+"""Test compound object with 3D record."""
 
 import warnings
 
@@ -16,7 +10,7 @@ from pubchempy import Compound, PubChemPyDeprecationWarning
 @pytest.fixture
 def c3d():
     """Compound CID 1234, 3D."""
-    return Compound.from_cid(1234, record_type='3d')
+    return Compound.from_cid(1234, record_type="3d")
 
 
 def test_properties_types(c3d):
@@ -35,21 +29,24 @@ def test_properties_types(c3d):
 
 
 def test_coordinate_type(c3d):
-    assert c3d.coordinate_type == '3d'
+    assert c3d.coordinate_type == "3d"
 
 
 def test_atoms(c3d):
     assert len(c3d.atoms) == 75
-    assert {a.element for a in c3d.atoms} == {'C', 'H', 'O', 'N'}
-    assert set(c3d.elements) == {'C', 'H', 'O', 'N'}
+    assert {a.element for a in c3d.atoms} == {"C", "H", "O", "N"}
+    assert set(c3d.elements) == {"C", "H", "O", "N"}
 
 
 def test_atoms_deprecated(c3d):
     with warnings.catch_warnings(record=True) as w:
-        assert {a['element'] for a in c3d.atoms} == {'C', 'H', 'O', 'N'}
+        assert {a["element"] for a in c3d.atoms} == {"C", "H", "O", "N"}
         assert len(w) == 1
         assert w[0].category == PubChemPyDeprecationWarning
-        assert str(w[0].message) == '__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated'
+        assert (
+            str(w[0].message)
+            == "__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated"
+        )
 
 
 def test_coordinates(c3d):
@@ -61,9 +58,12 @@ def test_coordinates(c3d):
 
 def test_coordinates_deprecated(c3d):
     with warnings.catch_warnings(record=True) as w:
-        assert isinstance(c3d.atoms[0]['x'], (float, int))
-        assert isinstance(c3d.atoms[0]['y'], (float, int))
-        assert isinstance(c3d.atoms[0]['z'], (float, int))
+        assert isinstance(c3d.atoms[0]["x"], (float, int))
+        assert isinstance(c3d.atoms[0]["y"], (float, int))
+        assert isinstance(c3d.atoms[0]["z"], (float, int))
         assert len(w) == 3
         assert w[0].category == PubChemPyDeprecationWarning
-        assert str(w[0].message) == '__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated'
+        assert (
+            str(w[0].message)
+            == "__getitem__ is deprecated: Dictionary style access to Atom attributes is deprecated"
+        )

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,10 +1,4 @@
-"""
-test_download
-~~~~~~~~~~~~~
-
-Test downloading.
-
-"""
+"""Test downloading."""
 
 import csv
 import os
@@ -16,7 +10,7 @@ import pytest
 from pubchempy import download
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def tmp_dir():
     dir = tempfile.mkdtemp()
     yield dir
@@ -24,17 +18,24 @@ def tmp_dir():
 
 
 def test_image_download(tmp_dir):
-    download('PNG', os.path.join(tmp_dir, 'aspirin.png'), 'Aspirin', 'name')
+    download("PNG", os.path.join(tmp_dir, "aspirin.png"), "Aspirin", "name")
     with pytest.raises(IOError):
-        download('PNG', os.path.join(tmp_dir, 'aspirin.png'), 'Aspirin', 'name')
-    download('PNG', os.path.join(tmp_dir, 'aspirin.png'), 'Aspirin', 'name', overwrite=True)
+        download("PNG", os.path.join(tmp_dir, "aspirin.png"), "Aspirin", "name")
+    download(
+        "PNG", os.path.join(tmp_dir, "aspirin.png"), "Aspirin", "name", overwrite=True
+    )
 
 
 def test_csv_download(tmp_dir):
-    download('CSV', os.path.join(tmp_dir, 's.csv'), [1, 2, 3], operation='property/ConnectivitySMILES,SMILES')
-    with open(os.path.join(tmp_dir, 's.csv')) as f:
+    download(
+        "CSV",
+        os.path.join(tmp_dir, "s.csv"),
+        [1, 2, 3],
+        operation="property/ConnectivitySMILES,SMILES",
+    )
+    with open(os.path.join(tmp_dir, "s.csv")) as f:
         rows = list(csv.reader(f))
-        assert rows[0] == ['CID', 'ConnectivitySMILES', 'SMILES']
-        assert rows[1][0] == '1'
-        assert rows[2][0] == '2'
-        assert rows[3][0] == '3'
+        assert rows[0] == ["CID", "ConnectivitySMILES", "SMILES"]
+        assert rows[1][0] == "1"
+        assert rows[2][0] == "2"
+        assert rows[3][0] == "3"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,10 +1,4 @@
-"""
-test_errors
-~~~~~~~~~~~~~
-
-Test errors.
-
-"""
+"""Test errors."""
 
 import pytest
 
@@ -21,11 +15,11 @@ from pubchempy import (
 def test_invalid_identifier():
     """BadRequestError should be raised if identifier is not a positive integer."""
     with pytest.raises(BadRequestError):
-        Compound.from_cid('aergaerhg')
+        Compound.from_cid("aergaerhg")
     with pytest.raises(BadRequestError):
-        get_compounds('srthrthsr')
+        get_compounds("srthrthsr")
     with pytest.raises(BadRequestError):
-        get_substances('grgrqjksa')
+        get_substances("grgrqjksa")
 
 
 def test_notfound_identifier():

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,10 +1,4 @@
-"""
-test_indentifiers
-~~~~~~~~~~~~~~~~~
-
-Test identifiers requests.
-
-"""
+"""Test identifiers requests."""
 
 from pubchempy import get_aids, get_cids, get_sids
 
@@ -12,20 +6,20 @@ from pubchempy import get_aids, get_cids, get_sids
 def test_identifiers_from_name():
     """Use a name input to retrieve lists of identifiers."""
     # Get CID for each compound linked to substances with name Aspirin
-    assert len(get_cids('Aspirin', 'name', 'substance')) >= 10
+    assert len(get_cids("Aspirin", "name", "substance")) >= 10
     # Get CID for each compound with name Aspirin
-    assert len(get_cids('Aspirin', 'name', 'compound')) >= 1
+    assert len(get_cids("Aspirin", "name", "compound")) >= 1
     # Get SID for substances linked to compound with name Aspirin
-    assert len(get_sids('Aspirin', 'name', 'substance')) >= 10
+    assert len(get_sids("Aspirin", "name", "substance")) >= 10
     # Get AID for each assay linked to substances with name Aspirin
-    assert len(get_aids('Aspirin', 'name', 'substance')) >= 10
+    assert len(get_aids("Aspirin", "name", "substance")) >= 10
     # Get AID for each assay linked to compound with name Aspirin
-    assert len(get_aids('Aspirin', 'name', 'compound')) >= 1
+    assert len(get_aids("Aspirin", "name", "compound")) >= 1
 
 
 def test_no_identifiers():
     """Test retrieving no identifier results."""
-    assert get_cids('asfgaerghaeirughae', 'name', 'substance') == []
-    assert get_cids('asfgaerghaeirughae', 'name', 'compound') == []
-    assert get_sids(999999999, 'cid', 'compound') == []
-    assert get_aids(12568, 'cid', 'compound') == []
+    assert get_cids("asfgaerghaeirughae", "name", "substance") == []
+    assert get_cids("asfgaerghaeirughae", "name", "compound") == []
+    assert get_sids(999999999, "cid", "compound") == []
+    assert get_aids(12568, "cid", "compound") == []

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,14 +1,8 @@
-"""
-test_pandas
-~~~~~~~~~~~
-
-Test optional pandas functionality.
-
-"""
+"""Test optional pandas functionality."""
 
 import logging
 
-import pytest
+import pandas as pd
 
 from pubchempy import (
     Compound,
@@ -23,37 +17,40 @@ from pubchempy import (
 log = logging.getLogger(__name__)
 
 
-# Import pandas as pd, skipping tests in this module if pandas is not installed
-pd = pytest.importorskip('pandas')
-
-
 def test_compounds_dataframe():
     """"""
-    df = get_compounds('C20H41Br', 'formula', as_dataframe=True)
+    df = get_compounds("C20H41Br", "formula", as_dataframe=True)
     assert df.ndim == 2
-    assert df.index.names == ['cid']
+    assert df.index.names == ["cid"]
     assert len(df.index) > 5
     columns = df.columns.values.tolist()
-    assert 'atom_stereo_count' in columns
-    assert 'atoms' in columns
-    assert 'connectivity_smiles' in columns
-    assert 'exact_mass' in columns
+    assert "atom_stereo_count" in columns
+    assert "atoms" in columns
+    assert "connectivity_smiles" in columns
+    assert "exact_mass" in columns
 
 
 def test_substances_dataframe():
     df = get_substances([1, 2, 3, 4], as_dataframe=True)
     assert df.ndim == 2
-    assert df.index.names == ['sid']
+    assert df.index.names == ["sid"]
     assert len(df.index) == 4
-    assert set(df.columns) == {'source_id', 'source_name', 'standardized_cid', 'synonyms'}
+    assert set(df.columns) == {
+        "source_id",
+        "source_name",
+        "standardized_cid",
+        "synonyms",
+    }
 
 
 def test_properties_dataframe():
-    df = get_properties(['smiles', 'xlogp', 'inchikey'], '1,2,3,4', 'cid', as_dataframe=True)
+    df = get_properties(
+        ["smiles", "xlogp", "inchikey"], "1,2,3,4", "cid", as_dataframe=True
+    )
     assert df.ndim == 2
-    assert df.index.names == ['CID']
+    assert df.index.names == ["CID"]
     assert len(df.index) == 4
-    assert set(df.columns) == {'SMILES', 'InChIKey', 'XLogP'}
+    assert set(df.columns) == {"SMILES", "InChIKey", "XLogP"}
 
 
 def test_compound_series():

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,50 +1,52 @@
-"""
-test_properties
-~~~~~~~~~~~~~~~
-
-Test properties requests.
-
-"""
+"""Test properties requests."""
 
 from pubchempy import get_properties, get_synonyms
 
 
 def test_properties():
     """"""
-    results = get_properties(['SMILES', 'InChIKey'], 'tris-(1,10-phenanthroline)ruthenium', 'name')
+    results = get_properties(
+        ["SMILES", "InChIKey"], "tris-(1,10-phenanthroline)ruthenium", "name"
+    )
     assert len(results) > 0
     for result in results:
-        assert 'CID' in result
-        assert 'SMILES' in result
-        assert 'InChIKey' in result
+        assert "CID" in result
+        assert "SMILES" in result
+        assert "InChIKey" in result
 
 
 def test_underscore_properties():
     """Properties can also be specified as underscore-separated words, rather than CamelCase."""
-    results = get_properties(['smiles', 'molecular_weight'], 'tris-(1,10-phenanthroline)ruthenium', 'name')
+    results = get_properties(
+        ["smiles", "molecular_weight"], "tris-(1,10-phenanthroline)ruthenium", "name"
+    )
     assert len(results) > 0
     for result in results:
-        assert 'CID' in result
-        assert 'SMILES' in result
-        assert 'MolecularWeight' in result
+        assert "CID" in result
+        assert "SMILES" in result
+        assert "MolecularWeight" in result
 
 
 def test_comma_string_properties():
     """Properties can also be specified as a comma-separated string, rather than a list."""
-    results = get_properties('smiles,InChIKey,molecular_weight', 'tris-(1,10-phenanthroline)ruthenium', 'name')
+    results = get_properties(
+        "smiles,InChIKey,molecular_weight",
+        "tris-(1,10-phenanthroline)ruthenium",
+        "name",
+    )
     assert len(results) > 0
     for result in results:
-        assert 'CID' in result
-        assert 'SMILES' in result
-        assert 'MolecularWeight' in result
-        assert 'InChIKey' in result
+        assert "CID" in result
+        assert "SMILES" in result
+        assert "MolecularWeight" in result
+        assert "InChIKey" in result
 
 
 def test_synonyms():
-    results = get_synonyms('C1=CC2=C(C3=C(C=CC=N3)C=C2)N=C1', 'smiles')
+    results = get_synonyms("C1=CC2=C(C3=C(C=CC=N3)C=C2)N=C1", "smiles")
     assert len(results) > 0
     for result in results:
-        assert 'CID' in result
-        assert 'Synonym' in result
-        assert isinstance(result['Synonym'], list)
-        assert len(result['Synonym']) > 0
+        assert "CID" in result
+        assert "Synonym" in result
+        assert isinstance(result["Synonym"], list)
+        assert len(result["Synonym"]) > 0

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,44 +1,44 @@
-"""
-test_requests
-~~~~~~~~~~~~~
-
-Test basic requests.
-
-"""
+"""Test basic requests."""
 
 from pubchempy import get_json, get_sids, request
 
 
 def test_requests():
     """Test a variety of basic raw requests and ensure they don't return an error code."""
-    assert request('c1ccccc1', 'smiles').getcode() == 200
-    assert request('DTP/NCI', 'sourceid', 'substance', '747285', 'SDF').getcode() == 200
-    assert request('coumarin', 'name', output='PNG', image_size='50x50').getcode() == 200
+    assert request("c1ccccc1", "smiles").getcode() == 200
+    assert request("DTP/NCI", "sourceid", "substance", "747285", "SDF").getcode() == 200
+    assert (
+        request("coumarin", "name", output="PNG", image_size="50x50").getcode() == 200
+    )
 
 
 def test_content_type():
     """Test content type header matches desired output format."""
-    assert request(241, output='JSON').headers['Content-Type'] == 'application/json'
-    assert request(241, output='XML').headers['Content-Type'] == 'application/xml'
-    assert request(241, output='SDF').headers['Content-Type'] == 'chemical/x-mdl-sdfile'
-    assert request(241, output='ASNT').headers['Content-Type'] == 'text/plain'
-    assert request(241, output='PNG').headers['Content-Type'] == 'image/png'
+    assert request(241, output="JSON").headers["Content-Type"] == "application/json"
+    assert request(241, output="XML").headers["Content-Type"] == "application/xml"
+    assert request(241, output="SDF").headers["Content-Type"] == "chemical/x-mdl-sdfile"
+    assert request(241, output="ASNT").headers["Content-Type"] == "text/plain"
+    assert request(241, output="PNG").headers["Content-Type"] == "image/png"
 
 
 def test_listkey_requests():
     """Test asynchronous listkey requests."""
-    r1 = get_json('CC', 'smiles', operation='cids', searchtype='superstructure')
-    assert 'IdentifierList' in r1 and 'CID' in r1['IdentifierList']
-    r2 = get_json('C10H21N', 'formula', listkey_count=3)
-    assert 'PC_Compounds' in r2 and len(r2['PC_Compounds']) == 3
+    r1 = get_json("CC", "smiles", operation="cids", searchtype="superstructure")
+    assert "IdentifierList" in r1 and "CID" in r1["IdentifierList"]
+    r2 = get_json("C10H21N", "formula", listkey_count=3)
+    assert "PC_Compounds" in r2 and len(r2["PC_Compounds"]) == 3
 
 
 def test_xref_request():
     """Test requests with xref inputs."""
-    response = request('EP0711162A1', 'PatentID', 'substance',  operation='sids', searchtype='xref')
+    response = request(
+        "EP0711162A1", "PatentID", "substance", operation="sids", searchtype="xref"
+    )
     assert response.code == 200
-    response2 = get_json('EP0711162A1', 'PatentID', 'substance', operation='sids', searchtype='xref')
-    assert 'IdentifierList' in response2
-    assert 'SID' in response2['IdentifierList']
-    sids = get_sids('EP0711162A1', 'PatentID', 'substance', searchtype='xref')
+    response2 = get_json(
+        "EP0711162A1", "PatentID", "substance", operation="sids", searchtype="xref"
+    )
+    assert "IdentifierList" in response2
+    assert "SID" in response2["IdentifierList"]
+    sids = get_sids("EP0711162A1", "PatentID", "substance", searchtype="xref")
     assert all(isinstance(sid, int) for sid in sids)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,10 +1,4 @@
-"""
-test_search
-~~~~~~~~~~~
-
-Test searching.
-
-"""
+"""Test searching."""
 
 from pubchempy import get_assays, get_compounds
 
@@ -16,8 +10,13 @@ def test_search_assays():
 
 
 def test_substructure():
-    results = get_compounds('C1=CC2=C(C3=C(C=CC=N3)C=C2)N=C1', 'smiles', searchtype='substructure', listkey_count=3)
+    results = get_compounds(
+        "C1=CC2=C(C3=C(C=CC=N3)C=C2)N=C1",
+        "smiles",
+        searchtype="substructure",
+        listkey_count=3,
+    )
     assert len(results) == 3
     for result in results:
-        assert all(el in [a.element for a in result.atoms] for el in {'C', 'N', 'H'})
+        assert all(el in [a.element for a in result.atoms] for el in {"C", "N", "H"})
         assert result.heavy_atom_count >= 14

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,10 +1,4 @@
-"""
-test_download
-~~~~~~~~~~~~~
-
-Test downloading.
-
-"""
+"""Test depositor sources."""
 
 from pubchempy import get_all_sources
 
@@ -14,15 +8,15 @@ def test_substance_sources():
     substance_sources = get_all_sources()
     assert len(substance_sources) > 20
     assert isinstance(substance_sources, list)
-    assert 'SureChEMBL' in substance_sources
-    assert 'DiscoveryGate' in substance_sources
-    assert 'ZINC' in substance_sources
+    assert "SureChEMBL" in substance_sources
+    assert "DiscoveryGate" in substance_sources
+    assert "ZINC" in substance_sources
 
 
 def test_assay_sources():
     """Retrieve a list of all Assay sources."""
-    assay_sources = get_all_sources('assay')
+    assay_sources = get_all_sources("assay")
     assert len(assay_sources) > 20
     assert isinstance(assay_sources, list)
-    assert 'ChEMBL' in assay_sources
-    assert 'DTP/NCI' in assay_sources
+    assert "ChEMBL" in assay_sources
+    assert "DTP/NCI" in assay_sources

--- a/tests/test_substance.py
+++ b/tests/test_substance.py
@@ -1,17 +1,11 @@
-"""
-test_substance
-~~~~~~~~~~~~~~
-
-Test substance object.
-
-"""
+"""Test substance object."""
 
 import pytest
 
 from pubchempy import Substance, get_substances
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def s1():
     """Substance SID 24864499."""
     return Substance.from_sid(24864499)
@@ -20,13 +14,16 @@ def s1():
 def test_basic(s1):
     """Test Substance is retrieved and has a record and correct SID."""
     assert s1.sid == 24864499
-    assert repr(s1) == 'Substance(24864499)'
+    assert repr(s1) == "Substance(24864499)"
     assert s1.record
 
 
 def test_substance_equality():
     assert Substance.from_sid(24864499) == Substance.from_sid(24864499)
-    assert get_substances('Coumarin 343, Dye Content 97 %', 'name')[0] == get_substances(24864499)[0]
+    assert (
+        get_substances("Coumarin 343, Dye Content 97 %", "name")[0]
+        == get_substances(24864499)[0]
+    )
 
 
 def test_synonyms(s1):
@@ -34,8 +31,8 @@ def test_synonyms(s1):
 
 
 def test_source(s1):
-    assert s1.source_name == 'Sigma-Aldrich'
-    assert s1.source_id == '393029_ALDRICH'
+    assert s1.source_name == "Sigma-Aldrich"
+    assert s1.source_id == "393029_ALDRICH"
 
 
 def test_deposited_compound(s1):


### PR DESCRIPTION
- Reformat all python code (including tests & notebooks) with ruff format. 
- Organize imports with `ruff --fix --select I`. 
- Fix `.pre-commit-config.yaml` to run formatting on each commit.