### PR TITLE
pytest rerun URLError

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 1
+      # max-parallel: 1
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "-v --reruns 3 --reruns-delay 5 --only-rerun TimeoutError --only-rerun ServerBusyError  --only-rerun RemoteDisconnected"
+addopts = "-v --reruns 3 --reruns-delay 5 --only-rerun TimeoutError --only-rerun ServerBusyError --only-rerun RemoteDisconnected --only-rerun URLError"
 testpaths = ["tests"]
 log_cli = true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,17 @@
 """Pytest configuration for PubChemPy tests."""
 
-import time
+# import time
 
-import pytest
+# import pytest
 
 
-@pytest.fixture(autouse=True)
-def rate_limit_tests():
-    """Limit the rate of requests to PubChem.
-
-    This fixture ensures that there is a delay between tests to avoid hitting
-    PubChem's rate limits, which can cause PubChemHTTPError: 'PUGREST.ServerBusy' to be
-    raised. A delay of 1 second is automatically applied between every test.
-    """
-    yield
-    time.sleep(1)
+# @pytest.fixture(autouse=True)
+# def rate_limit_tests():
+#     """Limit the rate of requests to PubChem.
+#
+#     This fixture ensures that there is a delay between tests to avoid hitting
+#     PubChem's rate limits, which can cause PubChemHTTPError: 'PUGREST.ServerBusy' to be
+#     raised. A delay of 1 second is automatically applied between every test.
+#     """
+#     yield
+#     time.sleep(1)


### PR DESCRIPTION
- Add URLError to the list of exceptions to rerun tests for
- Re-enable parallel tests in GitHub Actions CI
- Disable rate-limiter that pauses 1 second between tests

It looks like the rerun functionality is enough to ensure the tests pass, even without rate-limiting and running in serial. 