### PR TITLE
fix: avoid crashing if an assay is missing comment

### DIFF
--- a/pubchempy.py
+++ b/pubchempy.py
@@ -1983,8 +1983,9 @@ class Assay:
     def comments(self) -> list[str]:
         """Comments and additional information."""
         return [
-            comment for comment in self.record["assay"]["descr"]["comment"] if comment
+            comment for comment in self.record["assay"]["descr"].get("comment", "") if comment
         ]
+
 
     @property
     def results(self) -> list[dict[str, t.Any]]:


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>


Here is the code that was crashing before:

```python

import json
import pubchempy as pcp

assays = pcp.get_assays([2062])

for a in assays:
    print(a.to_dict())


```
